### PR TITLE
Adding support for automocking types with parameters that have constructors with parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _ReSharper.*/
+*.DotSettings
 *.suo
 *.swp
 *.user

--- a/Moq.AutoMock.Tests/AutoMockerTests.cs
+++ b/Moq.AutoMock.Tests/AutoMockerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Should;
 using Xunit;
+using System.Reflection;
 
 namespace Moq.AutoMock.Tests
 {
@@ -303,7 +304,7 @@ namespace Moq.AutoMock.Tests
 		    [Fact]
 		    public void It_creates_mocks_for_properties_with_public_getter_and_setter()
 		    {
-			    var instance = mocker.CreateInstance<ClassWithPublicProperties>();
+			    var instance = mocker.CreateInstance<ClassWithPublicProperties>(Assembly.GetExecutingAssembly());
 			    Assert.NotNull(instance.Property1);
 			    Assert.Null(instance.Property2);
 			    Assert.NotNull(instance.Property3);

--- a/Moq.AutoMock.Tests/AutoMockerTests.cs
+++ b/Moq.AutoMock.Tests/AutoMockerTests.cs
@@ -276,5 +276,41 @@ namespace Moq.AutoMock.Tests
                 mocker.VerifyAll();
             }
         }
+
+	    public class DescribeCreatingMocksForProperties
+	    {
+		    private AutoMocker mocker = new AutoMocker();
+
+		    public class Property1
+		    {
+		    }
+
+		    public class Property2
+		    {
+		    }
+
+		    public interface IProperty3
+		    {
+		    }
+
+		    public class ClassWithPublicProperties
+		    {
+			    public Property1 Property1 { get; set; }
+			    public Property2 Property2 { get; private set; }
+			    public IProperty3 Property3 { get; set; }
+		    }
+
+		    [Fact]
+		    public void It_creates_mocks_for_properties_with_public_getter_and_setter()
+		    {
+			    var instance = mocker.CreateInstance<ClassWithPublicProperties>();
+			    Assert.NotNull(instance.Property1);
+			    Assert.Null(instance.Property2);
+			    Assert.NotNull(instance.Property3);
+
+				Assert.Equal(mocker.GetMock<Property1>().Object, instance.Property1);
+				Assert.Equal(mocker.GetMock<IProperty3>().Object, instance.Property3);
+		    }
+	    }
     }
 }

--- a/Moq.AutoMock.Tests/AutoMockerTests.cs
+++ b/Moq.AutoMock.Tests/AutoMockerTests.cs
@@ -276,41 +276,5 @@ namespace Moq.AutoMock.Tests
                 mocker.VerifyAll();
             }
         }
-
-	    public class DescribeCreatingMocksForProperties
-	    {
-		    private AutoMocker mocker = new AutoMocker();
-
-		    public class Property1
-		    {
-		    }
-
-		    public class Property2
-		    {
-		    }
-
-		    public interface IProperty3
-		    {
-		    }
-
-		    public class ClassWithPublicProperties
-		    {
-			    public Property1 Property1 { get; set; }
-			    public Property2 Property2 { get; private set; }
-			    public IProperty3 Property3 { get; set; }
-		    }
-
-		    [Fact]
-		    public void It_creates_mocks_for_properties_with_public_getter_and_setter()
-		    {
-			    var instance = mocker.CreateInstance<ClassWithPublicProperties>();
-			    Assert.NotNull(instance.Property1);
-			    Assert.Null(instance.Property2);
-			    Assert.NotNull(instance.Property3);
-
-				Assert.Equal(mocker.GetMock<Property1>().Object, instance.Property1);
-				Assert.Equal(mocker.GetMock<IProperty3>().Object, instance.Property3);
-		    }
-	    }
     }
 }

--- a/Moq.AutoMock.Tests/AutoMockerTests.cs
+++ b/Moq.AutoMock.Tests/AutoMockerTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Should;
 using Xunit;
-using System.Reflection;
 
 namespace Moq.AutoMock.Tests
 {
@@ -304,7 +303,7 @@ namespace Moq.AutoMock.Tests
 		    [Fact]
 		    public void It_creates_mocks_for_properties_with_public_getter_and_setter()
 		    {
-			    var instance = mocker.CreateInstance<ClassWithPublicProperties>(Assembly.GetExecutingAssembly());
+			    var instance = mocker.CreateInstance<ClassWithPublicProperties>();
 			    Assert.NotNull(instance.Property1);
 			    Assert.Null(instance.Property2);
 			    Assert.NotNull(instance.Property3);

--- a/Moq.AutoMock.Tests/MockInstanceTests.cs
+++ b/Moq.AutoMock.Tests/MockInstanceTests.cs
@@ -1,0 +1,87 @@
+﻿using Xunit;
+
+namespace Moq.AutoMock.Tests
+{
+	public class MockInstanceTests
+	{
+		public interface ISomeInterface
+		{
+		}
+
+		[Fact]
+		public void Instance_creates_mock_for_interface()
+		{
+			var instance = new MockInstance(typeof(ISomeInterface));
+			Assert.NotNull(instance.Value);
+			var mock = Assert.IsType<Mock<ISomeInterface>>(instance.Mock);
+			Assert.NotNull(mock.Object);
+		}
+
+		public abstract class SomeAbstractClass
+		{
+		}
+
+		[Fact]
+		public void Instance_creates_mock_for_abstract_class()
+		{
+			var instance = new MockInstance(typeof(SomeAbstractClass));
+			Assert.NotNull(instance.Value);
+			var mock = Assert.IsType<Mock<SomeAbstractClass>>(instance.Mock);
+			Assert.NotNull(mock.Object);
+		}
+
+		public class ClassWithDefaultConstructor1
+		{
+		}
+
+		public class ClassWithDefaultConstructor2
+		{
+		}
+
+		[Fact]
+		public void Instance_creates_mock_for_class_with_default_constructor_only()
+		{
+			var instance = new MockInstance(typeof(ClassWithDefaultConstructor1));
+			Assert.NotNull(instance.Value);
+			var mock = Assert.IsType<Mock<ClassWithDefaultConstructor1>>(instance.Mock);
+			Assert.NotNull(mock.Object);
+		}
+
+		public class ClassWithConstructorParametersWhoseClassesHaveDefaultConstructor
+		{
+			public ClassWithConstructorParametersWhoseClassesHaveDefaultConstructor(ClassWithDefaultConstructor1 class1, ClassWithDefaultConstructor2 class2)
+			{
+			}
+		}
+
+		[Fact]
+		public void Instance_creates_mock_for_class_with_constructor_with_parameters_whose_classes_have_default_constructor()
+		{
+			var instance = new MockInstance(typeof(ClassWithConstructorParametersWhoseClassesHaveDefaultConstructor));
+			Assert.NotNull(instance.Value);
+			var mock = Assert.IsType<Mock<ClassWithConstructorParametersWhoseClassesHaveDefaultConstructor>>(instance.Mock);
+			Assert.NotNull(mock.Object);
+		}
+
+		public class ClassWithConstructorWithAllKindsOfParameters
+		{
+			public ClassWithConstructorWithAllKindsOfParameters(
+				ISomeInterface someInterface,
+				SomeAbstractClass someAbstractClass,
+				ClassWithDefaultConstructor1 class1,
+				ClassWithDefaultConstructor1 class2,
+				ClassWithConstructorParametersWhoseClassesHaveDefaultConstructor classWithParamsWithDefaultConstructors)
+			{
+			}
+		}
+
+		[Fact]
+		public void Instance_creates_mock_for_class_with_constructor_with_all_kinds_of_parameters()
+		{
+			var instance = new MockInstance(typeof(ClassWithConstructorWithAllKindsOfParameters));
+			Assert.NotNull(instance.Value);
+			var mock = Assert.IsType<Mock<ClassWithConstructorWithAllKindsOfParameters>>(instance.Mock);
+			Assert.NotNull(mock.Object);
+		}
+	}
+}

--- a/Moq.AutoMock.Tests/Moq.AutoMock.Tests.csproj
+++ b/Moq.AutoMock.Tests/Moq.AutoMock.Tests.csproj
@@ -53,6 +53,7 @@
   <ItemGroup>
     <Compile Include="AutoMockerTests.cs" />
     <Compile Include="ConstructorSelectorTests.cs" />
+    <Compile Include="MockInstanceTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Util.cs" />
   </ItemGroup>

--- a/Moq.AutoMock.Tests/Moq.AutoMock.Tests.csproj
+++ b/Moq.AutoMock.Tests/Moq.AutoMock.Tests.csproj
@@ -33,9 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Moq.4.1.1309.1617\lib\net40\Moq.dll</HintPath>
+    <Reference Include="Moq">
+      <HintPath>..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
     </Reference>
     <Reference Include="Should">
       <HintPath>..\packages\Should.1.1.12.0\lib\Should.dll</HintPath>

--- a/Moq.AutoMock.Tests/packages.config
+++ b/Moq.AutoMock.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.1.1309.1617" />
+  <package id="Moq" version="4.2.1402.2112" targetFramework="net40" />
   <package id="Should" version="1.1.12.0" />
   <package id="xunit" version="1.9.0.1566" />
 </packages>

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -23,24 +23,12 @@ namespace Moq.AutoMock
         /// <typeparam name="T">A concrete type</typeparam>
         /// <returns>An instance of T with all constructor arguments derrived from services 
         /// setup in the container.</returns>
-		public T CreateInstance<T>(params Assembly[] srcAssemblies)
+        public T CreateInstance<T>()
             where T : class
         {
 	        var type = typeof (T);
             var arguments = CreateArguments<T>();
             var instance = (T)Activator.CreateInstance(type, arguments);
-
-	        var tAssembly = typeof (T).Assembly;
-			if (srcAssemblies == null || srcAssemblies.Length == 0)
-			{
-				srcAssemblies = new [] { tAssembly };
-			}
-			else if (!srcAssemblies.Contains(tAssembly))
-			{
-				var assemblyList = srcAssemblies.ToList();
-				assemblyList.Add(tAssembly);
-				srcAssemblies = assemblyList.ToArray();
-			}
 
 			// We also want to create mocks for any public properties with getters and setters, which
 			// are not simple types or strings
@@ -49,8 +37,7 @@ namespace Moq.AutoMock
 		        .Where(p => (p.CanRead && p.GetGetMethod(true).IsPublic) &&
 		                    (p.CanWrite && p.GetSetMethod(true).IsPublic) &&
 		                    !p.PropertyType.IsArray && !p.PropertyType.IsValueType &&
-		                    (p.PropertyType.IsClass || p.PropertyType.IsInterface) &&
-							srcAssemblies.Contains(p.PropertyType.Assembly));
+		                    (p.PropertyType.IsClass || p.PropertyType.IsInterface));
 			foreach (var property in properties)
 			{
 				var propertyValue = GetObjectFor(property.PropertyType);

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -23,12 +23,24 @@ namespace Moq.AutoMock
         /// <typeparam name="T">A concrete type</typeparam>
         /// <returns>An instance of T with all constructor arguments derrived from services 
         /// setup in the container.</returns>
-        public T CreateInstance<T>()
+		public T CreateInstance<T>(params Assembly[] srcAssemblies)
             where T : class
         {
 	        var type = typeof (T);
             var arguments = CreateArguments<T>();
             var instance = (T)Activator.CreateInstance(type, arguments);
+
+	        var tAssembly = typeof (T).Assembly;
+			if (srcAssemblies == null || srcAssemblies.Length == 0)
+			{
+				srcAssemblies = new [] { tAssembly };
+			}
+			else if (!srcAssemblies.Contains(tAssembly))
+			{
+				var assemblyList = srcAssemblies.ToList();
+				assemblyList.Add(tAssembly);
+				srcAssemblies = assemblyList.ToArray();
+			}
 
 			// We also want to create mocks for any public properties with getters and setters, which
 			// are not simple types or strings
@@ -37,7 +49,8 @@ namespace Moq.AutoMock
 		        .Where(p => (p.CanRead && p.GetGetMethod(true).IsPublic) &&
 		                    (p.CanWrite && p.GetSetMethod(true).IsPublic) &&
 		                    !p.PropertyType.IsArray && !p.PropertyType.IsValueType &&
-		                    (p.PropertyType.IsClass || p.PropertyType.IsInterface));
+		                    (p.PropertyType.IsClass || p.PropertyType.IsInterface) &&
+							srcAssemblies.Contains(p.PropertyType.Assembly));
 			foreach (var property in properties)
 			{
 				var propertyValue = GetObjectFor(property.PropertyType);

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 using Moq.Language.Flow;
 
 namespace Moq.AutoMock
@@ -26,24 +25,8 @@ namespace Moq.AutoMock
         public T CreateInstance<T>()
             where T : class
         {
-	        var type = typeof (T);
             var arguments = CreateArguments<T>();
-            var instance = (T)Activator.CreateInstance(type, arguments);
-
-			// We also want to create mocks for any public properties with getters and setters, which
-			// are not simple types or strings
-	        var properties = type
-		        .GetProperties(BindingFlags.Instance | BindingFlags.Public)
-		        .Where(p => (p.CanRead && p.GetGetMethod(true).IsPublic) &&
-		                    (p.CanWrite && p.GetSetMethod(true).IsPublic) &&
-		                    !p.PropertyType.IsArray && !p.PropertyType.IsValueType &&
-		                    (p.PropertyType.IsClass || p.PropertyType.IsInterface));
-			foreach (var property in properties)
-			{
-				var propertyValue = GetObjectFor(property.PropertyType);
-				property.SetValue(instance, propertyValue, null);
-			}
-	        return instance;
+            return (T)Activator.CreateInstance(typeof(T), arguments);
         }
 
         private object[] CreateArguments<T>() where T : class

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using Moq.Language.Flow;
 
 namespace Moq.AutoMock
@@ -25,8 +26,24 @@ namespace Moq.AutoMock
         public T CreateInstance<T>()
             where T : class
         {
+	        var type = typeof (T);
             var arguments = CreateArguments<T>();
-            return (T)Activator.CreateInstance(typeof(T), arguments);
+            var instance = (T)Activator.CreateInstance(type, arguments);
+
+			// We also want to create mocks for any public properties with getters and setters, which
+			// are not simple types or strings
+	        var properties = type
+		        .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+		        .Where(p => (p.CanRead && p.GetGetMethod(true).IsPublic) &&
+		                    (p.CanWrite && p.GetSetMethod(true).IsPublic) &&
+		                    !p.PropertyType.IsArray && !p.PropertyType.IsValueType &&
+		                    (p.PropertyType.IsClass || p.PropertyType.IsInterface));
+			foreach (var property in properties)
+			{
+				var propertyValue = GetObjectFor(property.PropertyType);
+				property.SetValue(instance, propertyValue, null);
+			}
+	        return instance;
         }
 
         private object[] CreateArguments<T>() where T : class

--- a/Moq.AutoMock/Instance.cs
+++ b/Moq.AutoMock/Instance.cs
@@ -10,6 +10,8 @@ namespace Moq.AutoMock
 
     class MockInstance : IInstance
     {
+		private static readonly ConstructorSelector ConstructorSelector = new ConstructorSelector();
+
         public MockInstance(Mock value)
         {
             Mock = value;
@@ -22,9 +24,15 @@ namespace Moq.AutoMock
 
         private static Mock CreateMockOf(Type type)
         {
-            var mockType = typeof (Mock<>).MakeGenericType(type);
-            var mock = (Mock) Activator.CreateInstance(mockType);
-            return mock;
+			var mockType = typeof(Mock<>).MakeGenericType(type);
+			var ctor = ConstructorSelector.SelectFor(type);
+			object[] args = null;
+			if (ctor != null)
+				args = new object[ctor.GetParameters().Length];
+
+			return (args == null || args.Length == 0)
+				? (Mock)Activator.CreateInstance(mockType)
+				: (Mock)Activator.CreateInstance(mockType, new object[] { args });
         }
 
         public object Value

--- a/Moq.AutoMock/Moq.AutoMock.csproj
+++ b/Moq.AutoMock/Moq.AutoMock.csproj
@@ -33,9 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Moq.4.1.1309.1617\lib\net40\Moq.dll</HintPath>
+    <Reference Include="Moq">
+      <HintPath>..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Moq.AutoMock/packages.config
+++ b/Moq.AutoMock/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.1.1309.1617" />
+  <package id="Moq" version="4.2.1402.2112" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Hi Tim,

I think I got enough of the github figured out for now - I know I'm a few years behind but it's really cool, thanks for the intro :)

Here are the changes I mentioned before, and I looked at the test additions you suggested, for example:

```
var instance = new MockInstance(typeof (ISomeInterface));
Assert.NotNull(instance.Value);
var mock = Assert.IsType<Mock>(instance.Value);
Assert.NotNull(mock.Object);
```

These tests were failing with my changes but I think it's because instance.Value is the same as mock.Object, which is the dynamic proxy of the actual object and not the mock itself.  I would suggest that we implement these tests in the following manner (the differences are on lines 3 and 4):

```
var instance = new MockInstance(typeof(ISomeInterface));
Assert.NotNull(instance.Value);
var mock = Assert.IsType<Mock<ISomeInterface>>(instance.Mock);
Assert.NotNull(mock.Object);
```

What do you think?

Greg
