### PR TITLE
Support primitive return types in setup

### DIFF
--- a/Moq.AutoMock.Tests/AutoMockerTests.cs
+++ b/Moq.AutoMock.Tests/AutoMockerTests.cs
@@ -67,6 +67,8 @@ namespace Moq.AutoMock.Tests
             }
         }
 
+
+
         #endregion
 
         private static Type MockVerificationException
@@ -188,6 +190,15 @@ namespace Moq.AutoMock.Tests
                 mocker.Setup<IService1>(_ => _.Void()).Callback(() => x++);
                 mocker.Get<IService1>().Void();
                 x.ShouldEqual(1);
+            }
+
+            [Fact]
+            public void You_can_setup_a_method_that_returns_a_primitive()
+            {
+                mocker.Setup<IServiceWithPrimitives, long>(s => s.ReturnsALong()).Returns(100L);
+
+                var mock = mocker.Get<IServiceWithPrimitives>();
+                mock.ReturnsALong().ShouldEqual(100L);
             }
         }
 

--- a/Moq.AutoMock.Tests/Moq.AutoMock.Tests.csproj
+++ b/Moq.AutoMock.Tests/Moq.AutoMock.Tests.csproj
@@ -33,9 +33,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+    <Reference Include="Moq, Version=4.2.1402.2112, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Moq.4.1.1309.1617\lib\net40\Moq.dll</HintPath>
+      <HintPath>..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
     </Reference>
     <Reference Include="Should">
       <HintPath>..\packages\Should.1.1.12.0\lib\Should.dll</HintPath>

--- a/Moq.AutoMock.Tests/Util.cs
+++ b/Moq.AutoMock.Tests/Util.cs
@@ -24,4 +24,9 @@
     {
         string MainMethodName { get; }
     }
+
+    public interface IServiceWithPrimitives
+    {
+        long ReturnsALong();
+    }
 }

--- a/Moq.AutoMock.Tests/packages.config
+++ b/Moq.AutoMock.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.1.1309.1617" />
+  <package id="Moq" version="4.2.1402.2112" targetFramework="net40" />
   <package id="Should" version="1.1.12.0" />
   <package id="xunit" version="1.9.0.1566" />
 </packages>

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -171,6 +171,21 @@ namespace Moq.AutoMock
             return Setup<ISetup<TService>, TService>(m => m.Setup(setup));
         }
 
+        /// <summary>
+        /// Shortcut for mock.Setup(...), creating the mock when necessary.
+        /// For specific return types. E.g. primitive, structs
+        /// that cannot be infered
+        /// </summary>
+        /// <typeparam name="TService"></typeparam>
+        /// <typeparam name="TReturn"></typeparam>
+        /// <param name="setup"></param>
+        /// <returns></returns>
+        public ISetup<TService, TReturn> Setup<TService, TReturn>(Expression<Func<TService, TReturn>> setup)
+            where TService : class
+        {
+            return Setup<ISetup<TService, TReturn>, TService>(m => m.Setup(setup));
+        }
+
         private TReturn Setup<TReturn, TService>(Func<Mock<TService>, TReturn> returnValue)
             where TService : class
         {

--- a/Moq.AutoMock/Moq.AutoMock.csproj
+++ b/Moq.AutoMock/Moq.AutoMock.csproj
@@ -33,9 +33,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Moq, Version=4.0.10827.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+    <Reference Include="Moq, Version=4.2.1402.2112, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Moq.4.1.1309.1617\lib\net40\Moq.dll</HintPath>
+      <HintPath>..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Moq.AutoMock/packages.config
+++ b/Moq.AutoMock/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.1.1309.1617" />
+  <package id="Moq" version="4.2.1402.2112" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
New method which allows specifying the return type to support the above

Updated Moq version to 4.2
