### PR TITLE
Now unbundles exceptions from creating instances

### DIFF
--- a/Moq.AutoMock.Tests/AutoMockerTests.cs
+++ b/Moq.AutoMock.Tests/AutoMockerTests.cs
@@ -137,6 +137,13 @@ namespace Moq.AutoMock.Tests
             {
                 Assert.Throws<ArgumentException>(() => mocker.CreateInstance<ConstructorThrows>());
             }
+
+            [Fact]
+            public void It_throws_original_exception_caught_whilst_creating_object_with_original_stack_trace()
+            {
+                ArgumentException exception = Assert.Throws<ArgumentException>(() => mocker.CreateInstance<ConstructorThrows>());
+                Assert.Contains(typeof(ConstructorThrows).Name, exception.StackTrace);
+            }
         }
 
         public class DescribeUsingExplicitObjects

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -33,7 +33,7 @@ namespace Moq.AutoMock
             }
             catch (TargetInvocationException e)
             {
-                throw e.InnerException;
+                throw e.InnerException.PreserveStackTrace();
             }
         }
 

--- a/Moq.AutoMock/ExceptionExtensions.cs
+++ b/Moq.AutoMock/ExceptionExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Reflection;
+
+namespace Moq.AutoMock
+{
+    internal static class ExceptionExtensions
+    {
+        /// <summary>
+        /// Preserve the stack trance on an exception so it can be rethrown without losing that information
+        /// </summary>
+        /// <param name="ex">The exception to preserve the stack trace on</param>
+        public static Exception PreserveStackTrace(this Exception ex)
+        {
+            // If switching to .NET4.5+, the following line is a better method to use.
+            // ExceptionDispatchInfo.Capture(ex).Throw();
+
+            typeof(Exception).GetMethod("PrepForRemoting",
+                BindingFlags.NonPublic | BindingFlags.Instance)
+                .Invoke(ex, new object[0]);
+            return ex;
+        }
+    }
+}

--- a/Moq.AutoMock/Moq.AutoMock.csproj
+++ b/Moq.AutoMock/Moq.AutoMock.csproj
@@ -58,6 +58,7 @@
       <DependentUpon>AutoMocker.Verify.cs.tt</DependentUpon>
     </Compile>
     <Compile Include="ConstructorSelector.cs" />
+    <Compile Include="ExceptionExtensions.cs" />
     <Compile Include="Instance.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
Hi,

I have made a change to the `CreateInstance` method as I usually write tests for capturing exceptions in my constructors. Without this change, the exceptions are swallowed inside the call to `Activator.CreateInstance` and are wrapped inside a `TargetInvocationException`. This means that you cannot test the exception as easily as doing your usual `Assert.Throws(...)` method call.

Let me know what you think.

Ed
