### PR TITLE
Allow constructor with non-mockable parameter

### DIFF
--- a/Moq.AutoMock.Tests/ConstructorSelectorTests.cs
+++ b/Moq.AutoMock.Tests/ConstructorSelectorTests.cs
@@ -1,4 +1,5 @@
-﻿using Should;
+﻿using System;
+using Should;
 using Xunit;
 
 namespace Moq.AutoMock.Tests
@@ -37,29 +38,36 @@ namespace Moq.AutoMock.Tests
         [Fact]
         public void It_chooses_the_ctor_with_arguments()
         {
-            var ctor = selector.SelectFor(typeof (WithDefaultAndSingleParameter));
+            var ctor = selector.SelectFor(typeof (WithDefaultAndSingleParameter), new Type[0]);
             ctor.GetParameters().Length.ShouldEqual(1);
         }
 
         [Fact]
         public void It_chooses_the_ctor_with_the_most_arguments()
         {
-            var ctor = selector.SelectFor(typeof (With3Parameters));
+            var ctor = selector.SelectFor(typeof (With3Parameters), new Type[0]);
             ctor.GetParameters().Length.ShouldEqual(2);
         }
 
         [Fact]
         public void It_chooses_the_ctor_with_the_most_arguments_when_arguments_are_arrays()
         {
-            var ctor = selector.SelectFor(typeof(WithArrayParameter));
+            var ctor = selector.SelectFor(typeof(WithArrayParameter), new Type[0]);
             ctor.GetParameters().Length.ShouldEqual(1);
         }
 
         [Fact]
         public void It_wont_select_if_an_argument_is_sealed_and_not_array()
         {
-            var ctor = selector.SelectFor(typeof (WithSealedParameter));
+            var ctor = selector.SelectFor(typeof (WithSealedParameter), new Type[0]);
             ctor.GetParameters().Length.ShouldEqual(0);
+        }
+
+        [Fact]
+        public void It_will_select_if_an_argument_is_sealed_and_supplied()
+        {
+            var ctor = selector.SelectFor(typeof (WithSealedParameter), new Type[] { typeof(string) });
+            ctor.GetParameters().Length.ShouldEqual(1);
         }
     }
 }

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -39,7 +39,7 @@ namespace Moq.AutoMock
 
         private object[] CreateArguments<T>() where T : class
         {
-            var ctor = constructorSelector.SelectFor(typeof (T));
+            var ctor = constructorSelector.SelectFor(typeof (T), typeMap.Keys.ToArray());
             var arguments = ctor.GetParameters().Select(x => GetObjectFor(x.ParameterType)).ToArray();
             return arguments;
         }

--- a/Moq.AutoMock/ConstructorSelector.cs
+++ b/Moq.AutoMock/ConstructorSelector.cs
@@ -6,23 +6,25 @@ namespace Moq.AutoMock
 {
     internal class ConstructorSelector
     {
-        public ConstructorInfo SelectFor(Type type)
+        public ConstructorInfo SelectFor(Type type, Type[] existingTypes)
         {
             ConstructorInfo best = null;
             foreach (var constructor in type.GetConstructors())
             {
-                if (IsBetterChoice(best, constructor))
+                if (IsBetterChoice(best, constructor, existingTypes))
                     best = constructor;
             }
             return best;
         }
 
-        private bool IsBetterChoice(ConstructorInfo current, ConstructorInfo candidate)
+        private bool IsBetterChoice(ConstructorInfo current, ConstructorInfo candidate, Type[] existingTypes)
         {
             if (current == null)
                 return true;
 
-            if (candidate.GetParameters().Any(x => x.ParameterType.IsSealed && !x.ParameterType.IsArray))
+            if (candidate.GetParameters()
+                         .Where(x => !existingTypes.Contains(x.ParameterType))
+                         .Any(x => x.ParameterType.IsSealed && !x.ParameterType.IsArray))
                 return false;
 
             return current.GetParameters().Length < candidate.GetParameters().Length;


### PR DESCRIPTION
If suitable non-mockable objects have been supplied to the AutoMocker, there is no reason not to select a constructor that uses these objects.  In my case, my IOC would inject Func's into my classes.  The AutoMocker would not allow these to be used alongside genuine mocks, even if my test code was supplying the correct Func's.
