### PR TITLE
Added the ability to use internal/private constructors when mocking.

### DIFF
--- a/Moq.AutoMock.Tests/AutoMockerTests.cs
+++ b/Moq.AutoMock.Tests/AutoMockerTests.cs
@@ -32,6 +32,20 @@ namespace Moq.AutoMock.Tests
             }
         }
 
+        public class WithServiceInternal
+        {
+            public IService1 Service { get; set; }
+
+            internal WithServiceInternal(IService1 service)
+            {
+                Service = service;
+            }
+
+            public WithServiceInternal() : this(null)
+            {                
+            }
+        }
+
         public class WithServiceArray
         {
             public IService2[] Services { get; set; }
@@ -107,6 +121,13 @@ namespace Moq.AutoMock.Tests
             {
                 var instance = mocker.CreateInstance<OneConstructor>();
                 Mock.Get(instance.Empty).ShouldNotBeNull();
+            }
+
+            [Fact]
+            public void It_creates_mock_objects_for_internal_ctor_parameters()
+            {
+                var instance = mocker.CreateInstance<WithServiceInternal>(true);
+                Mock.Get(instance.Service).ShouldNotBeNull();
             }
 
             [Fact]

--- a/Moq.AutoMock/ConstructorSelector.cs
+++ b/Moq.AutoMock/ConstructorSelector.cs
@@ -6,10 +6,10 @@ namespace Moq.AutoMock
 {
     internal class ConstructorSelector
     {
-        public ConstructorInfo SelectFor(Type type, Type[] existingTypes)
+        public ConstructorInfo SelectFor(Type type, Type[] existingTypes, BindingFlags bindingFlags)
         {
             ConstructorInfo best = null;
-            foreach (var constructor in type.GetConstructors())
+            foreach (var constructor in type.GetConstructors(bindingFlags))
             {
                 if (IsBetterChoice(best, constructor, existingTypes))
                     best = constructor;


### PR DESCRIPTION
I'm not sure how many people will find this useful, but at least for my purposes I frequently find myself wanting to mock something like in the example below, and until now have had to create my Mocks manually.

```
public class MyPublicClass
{
    private readonly IMyPrivateService _serviceA;

    internal MyPublicClass(IMyPrivateService service)
    {
        _service = service;
    }
    ... 
}
```

I have simply added an overload `CreateInstance<T>(bool enablePrivate)` to the AutoMocker that turns on non-public constructors. This is achieved by supplying the necessary `BindingFlags` when doing any reflection.
