### PR TITLE
Use MockRepository so all mocks are verified at once

### DIFF
--- a/Moq.AutoMock.Tests/AutoMockerTests.cs
+++ b/Moq.AutoMock.Tests/AutoMockerTests.cs
@@ -143,6 +143,21 @@ namespace Moq.AutoMock.Tests
                 var mock = Mock.Get(instance.Empty);
                 Assert.IsNotNull(mock);
                 Assert.AreEqual(MockBehavior.Strict, mock.Behavior);
+                Assert.AreEqual(MockBehavior.Strict, strictMocker.MockBehavior);
+                Assert.AreEqual(DefaultValue.Empty, strictMocker.DefaultValue);
+            }
+
+            [TestMethod]
+            public void It_creates_mock_objects_for_ctor_parameters_with_loose_behavior()
+            {
+                var looseMocker = new AutoMocker(MockBehavior.Loose, DefaultValue.Mock);
+
+                var instance = looseMocker.CreateInstance<WithService>();
+                var mock = Mock.Get(instance.Service);
+                Assert.IsNotNull(instance.Service.Other);
+                Assert.AreEqual(MockBehavior.Loose, mock.Behavior);
+                Assert.AreEqual(MockBehavior.Loose, looseMocker.MockBehavior);
+                Assert.AreEqual(DefaultValue.Mock, looseMocker.DefaultValue);
             }
 
             [TestMethod]
@@ -471,6 +486,7 @@ namespace Moq.AutoMock.Tests
                 var _ = mocker.CreateInstance<WithService>();
                 var ex = Assert.ThrowsException<MockException>(() => mocker.VerifyAll());
                 Assert.IsTrue(ex.IsVerificationError);
+                // TODO: short of string matching "=>" how to verify both errors were caught in a single exception?
             }
 
             [TestMethod]

--- a/Moq.AutoMock.Tests/Moq.AutoMock.Tests.csproj
+++ b/Moq.AutoMock.Tests/Moq.AutoMock.Tests.csproj
@@ -25,7 +25,6 @@
   <ItemGroup>
     <PackageReference Include="Moq" version="4.8.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
     <ProjectReference Include="..\Moq.AutoMock\Moq.AutoMock.csproj" />

--- a/Moq.AutoMock/Instance.cs
+++ b/Moq.AutoMock/Instance.cs
@@ -48,18 +48,6 @@ namespace Moq.AutoMock
             Mock = value;
         }
 
-        public MockInstance(Type mockType, MockBehavior mockBehavior)
-            :this(CreateMockOf(mockType, mockBehavior))
-        {
-        }
-
-        private static Mock CreateMockOf(Type type, MockBehavior mockBehavior)
-        {
-            var mockType = typeof (Mock<>).MakeGenericType(type);
-            var mock = (Mock) Activator.CreateInstance(mockType, mockBehavior);
-            return mock;
-        }
-
         public object Value => Mock.Object;
 
         public Mock Mock { get; }

--- a/Moq.AutoMock/MockRepositoryShim.cs
+++ b/Moq.AutoMock/MockRepositoryShim.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Moq.AutoMock
+{
+    // FRAGILE: Necessary to shim outside mocks into the repository, see https://github.com/moq/moq4/issues/617
+    public class MockRepositoryShim : MockRepository
+    {
+        private readonly FieldInfo defaultBehaviorProp;
+
+        public MockRepositoryShim(MockBehavior defaultBehavior)
+            : base(defaultBehavior)
+        {
+#pragma warning disable 618
+            // FRAGILE: MockFactory will be removed in v5
+            defaultBehaviorProp = (
+                from p in typeof(MockFactory).GetRuntimeFields().ToList()
+                where p.Name == "defaultBehavior"
+                select p
+            ).First();
+#pragma warning restore 618
+        }
+
+        public MockBehavior MockBehavior
+        {
+            get => (MockBehavior)this.defaultBehaviorProp.GetValue(this);
+            set => this.defaultBehaviorProp.SetValue(this, value);
+        }
+
+        public void Add(Mock mock)
+        {
+            var mocks = (ICollection<Mock>)this.Mocks;
+            if (!mocks.Contains(mock))
+            {
+                mocks.Add(mock);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Building atop https://github.com/tkellogg/Moq.AutoMocker/pull/34, this uses a MockRepository under the hood to ensure all mocks are verified at once rather than stopping on the first `.Verify()` fail.

FRAGILE: this does reflection into MockRepository in ways that will change in v5, see https://github.com/moq/moq4/issues/617