### PR TITLE
Try a different approach to pre/release build versions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-
+version: 1.0.{build}
 image: Visual Studio 2017
 configuration: Release
 skip_tags: true
@@ -36,11 +36,7 @@ nuget:
 
 for:
 -
-  version: 1.0.{build}-pre
-
--
   branches:
-    only:
+    except:
       - release
-  version: 1.0.{build}
-
+  version: $(APPVEYOR_BUILD_VERSION)-pre


### PR DESCRIPTION
As the 1.0 release was prepped, AppVeyor attempted to build the release as a `-pre` package still. Examples for versioning like this are sparse, so this is still an attempt to manage that versioning correctly.