### PR TITLE
Align multi-targeting with Moq4

### DIFF
--- a/Moq.AutoMock.Tests/Moq.AutoMock.Tests.csproj
+++ b/Moq.AutoMock.Tests/Moq.AutoMock.Tests.csproj
@@ -24,9 +24,9 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" version="4.8.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <ProjectReference Include="..\Moq.AutoMock\Moq.AutoMock.csproj" />
   </ItemGroup>
 

--- a/Moq.AutoMock/Moq.AutoMock.csproj
+++ b/Moq.AutoMock/Moq.AutoMock.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
     <OutputType>Library</OutputType>
     <RootNamespace>Moq.AutoMock</RootNamespace>
     <AssemblyName>Moq.AutoMock</AssemblyName>
@@ -13,7 +13,7 @@
     <Authors>Tim Kellogg,Adam Hewitt,Kevin Bost</Authors>
     <PackageDescription>An auto-mocking container that generates mocks using Moq</PackageDescription>
     <Copyright>Copyright Tim Kellogg 2018</Copyright>
-    <PackageLicenseUrl>https://github.com/moq/Moq.AutoMocker/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/moq/Moq.AutoMocker</PackageProjectUrl>
     <Tags>moq;automocking;testing;TDD</Tags>
 
@@ -32,12 +32,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <!--<Compile Include="**\*.cs" Exclude="**\*.generated.cs"/>
-    <Compile Include="AutoMocker.Combine.cs.generated.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>AutoMocker.Combine.cs.tt</DependentUpon>
-    </Compile>-->
+    <None Include="..\LICENSE" Pack="true" PackagePath="$(PackageLicenseFile)"/>
     <None Include="AutoMocker.Combine.cs.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>AutoMocker.Combine.cs.generated.cs</LastGenOutput>


### PR DESCRIPTION
Fix #59 by leaving NETStandard out of full .NET builds.