### PR TITLE
Include xmldoc comments in Nuget packages

### DIFF
--- a/Moq.AutoMock/Moq.AutoMock.csproj
+++ b/Moq.AutoMock/Moq.AutoMock.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <None Include="..\LICENSE" Pack="true" PackagePath="$(PackageLicenseFile)"/>
+    <None Include="..\LICENSE" Pack="true" PackagePath=""/>
     <None Include="AutoMocker.Combine.cs.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>AutoMocker.Combine.cs.generated.cs</LastGenOutput>

--- a/Moq.AutoMock/Moq.AutoMock.csproj
+++ b/Moq.AutoMock/Moq.AutoMock.csproj
@@ -17,6 +17,10 @@
     <PackageProjectUrl>https://github.com/moq/Moq.AutoMocker</PackageProjectUrl>
     <Tags>moq;automocking;testing;TDD</Tags>
 
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- Suppress CS1591: Missing XML comment for publicly visible type or member -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors),CS1591</WarningsNotAsErrors>
+
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <DebugType>embedded</DebugType>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
Currently, the comments aren't included in the Nuget packages. This PR turns on their creation and packaging.