### PR TITLE
Add method for sequence setup

### DIFF
--- a/Moq.AutoMock.Tests/DescribeSetups.cs
+++ b/Moq.AutoMock.Tests/DescribeSetups.cs
@@ -87,5 +87,19 @@ namespace Moq.AutoMock.Tests
 
             Assert.AreEqual("aname", mock.Name);
         }
+
+        [TestMethod]
+        public void You_can_setup_a_method_that_returns_diffrent_result_in_sequence()
+        {
+            var mocker = new AutoMocker();
+            mocker.SetupSequence<IService4, string>(p => p.MainMethodName(It.IsAny<string>()))
+                .Returns("t1")
+                .Returns("t2");
+
+            var mock = mocker.Get<IService4>();
+
+            Assert.AreEqual("t1", mock.MainMethodName("any"));
+            Assert.AreEqual("t2", mock.MainMethodName("any"));
+        }
     }
 }

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
+using Moq.Language;
 
 namespace Moq.AutoMock
 {
@@ -346,6 +347,18 @@ namespace Moq.AutoMock
             return mock;
         }
 
+        /// <summary>
+        /// Shortcut for mock.SetupSequence(), creating the mock when necessary
+        /// </summary>
+        /// <typeparam name="TService"></typeparam>
+        /// <typeparam name="TReturn"></typeparam>
+        /// <returns></returns>
+        public ISetupSequentialResult<TReturn> SetupSequence<TService, TReturn>(Expression<Func<TService, TReturn>> setup)
+            where TService : class
+        {
+            return Setup<ISetupSequentialResult<TReturn>, TService>(m => m.SetupSequence(setup));
+        }
+
         #endregion
 
         #region Combine
@@ -503,6 +516,5 @@ namespace Moq.AutoMock
         }
 
         #endregion
-
     }
 }


### PR DESCRIPTION
As explained in #66 i think this is a useful method to have. As @Keboo mentions in the issue, it could be  better to have it as an extension instead. 

I have currently added it as a method on the AutoMocker class, but could be refactored pretty easily. UnitTest was created with the other Setup tests, if you want i can move that as well to a more appropriate place.