### PR TITLE
Make SourceLink private

### DIFF
--- a/Moq.AutoMock/Moq.AutoMock.csproj
+++ b/Moq.AutoMock/Moq.AutoMock.csproj
@@ -30,7 +30,9 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" >
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Moq" Version="4.13.1" />
   </ItemGroup>
   


### PR DESCRIPTION
Resolves #82, I'm not sure why updating the dependency would have dropped this.