### PR TITLE
Allow transitive dependencies

### DIFF
--- a/Moq.AutoMock.Tests/DescribeCreateInstance.cs
+++ b/Moq.AutoMock.Tests/DescribeCreateInstance.cs
@@ -138,5 +138,15 @@ namespace Moq.AutoMock.Tests
             // Questionable if this is the correct behavior, but it is the current behavior.
             Assert.AreSame(dependency, mocker.Get<WithService>());
         }
+
+        [TestMethod]
+        public void It_creates_object_with_recursive_dependency()
+        {
+            var mocker = new AutoMocker();
+            // I could see this changing to something else in the future, like null. Right now, it seems
+            // best to cause early failure to clarify what went wrong. Also, returning null "allows" the
+            // behavior, so it's easier to move that direction later without breaking backward compatibility.
+            Assert.ThrowsException<InvalidOperationException>(mocker.CreateInstance<WithRecursiveDependency>);
+        }
     }
 }

--- a/Moq.AutoMock.Tests/DescribeCreateInstance.cs
+++ b/Moq.AutoMock.Tests/DescribeCreateInstance.cs
@@ -95,5 +95,48 @@ namespace Moq.AutoMock.Tests
             ArgumentException exception = Assert.ThrowsException<ArgumentException>(() => mocker.CreateInstance<ConstructorThrows>());
             StringAssert.Contains(exception.StackTrace, typeof(ConstructorThrows).Name);
         }
+
+        [TestMethod]
+        public void It_creates_object_when_first_level_dependencies_are_classes()
+        {
+            var mocker = new AutoMocker();
+            HasClassDependency instance = mocker.CreateInstance<HasClassDependency>();
+            var dependency = instance.WithService;
+            Assert.IsNotNull(dependency);
+            Assert.IsInstanceOfType(dependency, typeof(WithService));
+            Assert.IsInstanceOfType(Mock.Get(dependency), typeof(Mock<WithService>));
+            Assert.AreSame(dependency, mocker.Get<WithService>());
+        }
+
+        [TestMethod]
+        public void It_creates_object_with_2_first_level_dependencies()
+        {
+            var mocker = new AutoMocker();
+            var instance = mocker.CreateInstance<With2ClassDependencies>();
+            
+            var dependency1 = instance.WithService;
+            Assert.IsNotNull(dependency1);
+            Assert.IsInstanceOfType(dependency1, typeof(WithService));
+            Assert.IsInstanceOfType(Mock.Get(dependency1), typeof(Mock<WithService>));
+            Assert.AreSame(dependency1, mocker.Get<WithService>());
+            
+            var dependency2 = instance.With3Parameters;
+            Assert.IsNotNull(dependency2);
+            Assert.IsInstanceOfType(dependency2, typeof(With3Parameters));
+            Assert.IsInstanceOfType(Mock.Get(dependency2), typeof(Mock<With3Parameters>));
+        }
+
+        [TestMethod]
+        public void Second_level_dependencies_act_same_as_if_they_were_target()
+        {
+            var mocker = new AutoMocker();
+            var instance = mocker.CreateInstance<HasFuncDependencies>();
+            var dependency = instance.WithServiceFactory();
+            Assert.IsNotNull(dependency);
+            Assert.IsInstanceOfType(dependency, typeof(WithService));
+            Assert.IsInstanceOfType(Mock.Get(dependency), typeof(Mock<WithService>));
+            // Questionable if this is the correct behavior, but it is the current behavior.
+            Assert.AreSame(dependency, mocker.Get<WithService>());
+        }
     }
 }

--- a/Moq.AutoMock.Tests/DescribeCreateInstance.cs
+++ b/Moq.AutoMock.Tests/DescribeCreateInstance.cs
@@ -140,7 +140,7 @@ namespace Moq.AutoMock.Tests
         }
 
         [TestMethod]
-        public void It_creates_object_with_recursive_dependency()
+        public void It_throws_when_creating_object_with_recursive_dependency()
         {
             var mocker = new AutoMocker();
             // I could see this changing to something else in the future, like null. Right now, it seems

--- a/Moq.AutoMock.Tests/Util/HasClassDependency.cs
+++ b/Moq.AutoMock.Tests/Util/HasClassDependency.cs
@@ -1,0 +1,12 @@
+namespace Moq.AutoMock.Tests.Util
+{
+    public class HasClassDependency
+    {
+        public WithService WithService { get; }
+        
+        public HasClassDependency(WithService withService)
+        {
+            WithService = withService;
+        }
+    }
+}

--- a/Moq.AutoMock.Tests/Util/HasFuncDependencies.cs
+++ b/Moq.AutoMock.Tests/Util/HasFuncDependencies.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Moq.AutoMock.Tests.Util
+{
+    public class HasFuncDependencies
+    {
+        public Func<WithService> WithServiceFactory { get; }
+        
+        public HasFuncDependencies(Func<WithService> withServiceFactory)
+        {
+            WithServiceFactory = withServiceFactory;
+        }
+    }
+}

--- a/Moq.AutoMock.Tests/Util/With2ClassDependencies.cs
+++ b/Moq.AutoMock.Tests/Util/With2ClassDependencies.cs
@@ -1,8 +1,6 @@
 namespace Moq.AutoMock.Tests.Util
 {
-#pragma warning disable CA1812  //is an internal class that is apparently never instantiated
-    internal class With2ClassDependencies
-#pragma warning restore CA1812
+    public class With2ClassDependencies
     {
         public WithService WithService { get; }
         public With3Parameters With3Parameters { get; }

--- a/Moq.AutoMock.Tests/Util/With2ClassDependencies.cs
+++ b/Moq.AutoMock.Tests/Util/With2ClassDependencies.cs
@@ -1,0 +1,16 @@
+namespace Moq.AutoMock.Tests.Util
+{
+#pragma warning disable CA1812  //is an internal class that is apparently never instantiated
+    internal class With2ClassDependencies
+#pragma warning restore CA1812
+    {
+        public WithService WithService { get; }
+        public With3Parameters With3Parameters { get; }
+        
+        public With2ClassDependencies(WithService withService, With3Parameters with3Parameters)
+        {
+            WithService = withService;
+            With3Parameters = with3Parameters;
+        }
+    }
+}

--- a/Moq.AutoMock.Tests/Util/With3Parameters.cs
+++ b/Moq.AutoMock.Tests/Util/With3Parameters.cs
@@ -1,7 +1,7 @@
 ﻿namespace Moq.AutoMock.Tests.Util
 {
 #pragma warning disable CA1801, CA1812  //is an internal class that is apparently never instantiated
-    internal class With3Parameters
+    public class With3Parameters
     {
         // ReSharper disable UnusedMember.Global
         // ReSharper disable UnusedParameter.Local

--- a/Moq.AutoMock.Tests/Util/With3Parameters.cs
+++ b/Moq.AutoMock.Tests/Util/With3Parameters.cs
@@ -1,13 +1,16 @@
 ﻿namespace Moq.AutoMock.Tests.Util
 {
-#pragma warning disable CA1801, CA1812  //is an internal class that is apparently never instantiated
     public class With3Parameters
     {
         // ReSharper disable UnusedMember.Global
         // ReSharper disable UnusedParameter.Local
         public With3Parameters() { }
+
+#pragma warning disable CA1801  //Parameter  is never used. Remove the parameter or use it in the method body
         public With3Parameters(IService1 service1) { }
         public With3Parameters(IService1 service1, IService2 service2) { }
+#pragma warning restore CA1801
+
         // ReSharper restore UnusedParameter.Local
         // ReSharper restore UnusedMember.Global
     }

--- a/Moq.AutoMock.Tests/Util/WithArrayParameter.cs
+++ b/Moq.AutoMock.Tests/Util/WithArrayParameter.cs
@@ -1,13 +1,16 @@
 ﻿namespace Moq.AutoMock.Tests.Util
 {
-#pragma warning disable CA1801, CA1812  //is an internal class that is apparently never instantiated
-    internal class WithArrayParameter
+    public class WithArrayParameter
     {
         // ReSharper disable UnusedMember.Global
         // ReSharper disable UnusedParameter.Local
         public WithArrayParameter() { }
+
+#pragma warning disable CA1801  //Parameter  is never used. Remove the parameter or use it in the method body
         public WithArrayParameter(string[] array) { }
         public WithArrayParameter(string[] array, string @sealed) { }
+#pragma warning restore CA1801
+
         // ReSharper restore UnusedParameter.Local
         // ReSharper restore UnusedMember.Global
     }

--- a/Moq.AutoMock.Tests/Util/WithDefaultAndSingleParameter.cs
+++ b/Moq.AutoMock.Tests/Util/WithDefaultAndSingleParameter.cs
@@ -1,12 +1,15 @@
 ﻿namespace Moq.AutoMock.Tests.Util
 {
-#pragma warning disable CA1801, CA1812  //is an internal class that is apparently never instantiated
-    internal class WithDefaultAndSingleParameter
+    public class WithDefaultAndSingleParameter
     {
         // ReSharper disable UnusedMember.Global
         // ReSharper disable UnusedParameter.Local
         public WithDefaultAndSingleParameter() { }
+
+#pragma warning disable CA1801  //Parameter  is never used. Remove the parameter or use it in the method body
         public WithDefaultAndSingleParameter(IService1 service1) { }
+#pragma warning restore CA1801
+
         // ReSharper restore UnusedParameter.Local
         // ReSharper restore UnusedMember.Global
     }

--- a/Moq.AutoMock.Tests/Util/WithPrivateConstructor.cs
+++ b/Moq.AutoMock.Tests/Util/WithPrivateConstructor.cs
@@ -1,13 +1,16 @@
 ﻿namespace Moq.AutoMock.Tests.Util
 {
-#pragma warning disable CA1801, CA1812  //is an internal class that is apparently never instantiated
-    internal class WithPrivateConstructor
+    public class WithPrivateConstructor
     {
         // ReSharper disable UnusedMember.Global
         // ReSharper disable UnusedParameter.Local
         // ReSharper disable UnusedMember.Local
+
+#pragma warning disable CA1801  //Parameter  is never used. Remove the parameter or use it in the method body
         public WithPrivateConstructor(IService1 service1) { }
         private WithPrivateConstructor(IService1 service1, IService2 service2) { }
+#pragma warning restore CA1801
+
         // ReSharper restore UnusedMember.Local
         // ReSharper restore UnusedParameter.Local
         // ReSharper restore UnusedMember.Global

--- a/Moq.AutoMock.Tests/Util/WithRecursiveDependency.cs
+++ b/Moq.AutoMock.Tests/Util/WithRecursiveDependency.cs
@@ -1,0 +1,12 @@
+namespace Moq.AutoMock.Tests.Util
+{
+    public class WithRecursiveDependency
+    {
+        public WithRecursiveDependency Child { get; }
+        
+        public WithRecursiveDependency(WithRecursiveDependency child)
+        {
+            Child = child;
+        }
+    }
+}

--- a/Moq.AutoMock.Tests/Util/WithSealedParameter.cs
+++ b/Moq.AutoMock.Tests/Util/WithSealedParameter.cs
@@ -1,12 +1,15 @@
 ﻿namespace Moq.AutoMock.Tests.Util
 {
-#pragma warning disable CA1801, CA1812  //is an internal class that is apparently never instantiated
-    internal class WithSealedParameter
+    public class WithSealedParameter
     {
         // ReSharper disable UnusedMember.Global
         // ReSharper disable UnusedParameter.Local
         public WithSealedParameter() { }
+
+#pragma warning disable CA1801  //Parameter  is never used. Remove the parameter or use it in the method body
         public WithSealedParameter(string @sealed) { }
+#pragma warning restore CA1801  //Parameter  is never used. Remove the parameter or use it in the method body
+
         // ReSharper restore UnusedParameter.Local
         // ReSharper restore UnusedMember.Global
     }

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -229,7 +229,7 @@ namespace Moq.AutoMock
         /// <typeparam name="TService">The type that the instance will be registered as</typeparam>
         /// <param name="service"></param>
         public void Use<TService>([DisallowNull] TService service)
-            => Use(typeof(TService), service);
+            => Use(typeof(TService), service ?? throw new ArgumentNullException(nameof(service)));
 
         /// <summary>
         /// Adds an instance to the container.

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -555,6 +555,11 @@ namespace Moq.AutoMock
             return bindingFlags;
         }
 
+        internal object?[] CreateArguments(Type type)
+        {
+            return CreateArguments(type, GetBindingFlags(false));
+        }
+        
         private object?[] CreateArguments(Type type, BindingFlags bindingFlags)
         {
             ConstructorInfo ctor = type.SelectCtor(_typeMap.Keys.ToArray(), bindingFlags);

--- a/Moq.AutoMock/ObjectGraphContext.cs
+++ b/Moq.AutoMock/ObjectGraphContext.cs
@@ -7,16 +7,16 @@ namespace Moq.AutoMock
     /// <summary>
     /// Handles state while creating an object graph.
     /// </summary>
-    public class ResolutionContext
+    public class ObjectGraphContext
     {
         /// <summary>
         /// Creates an instance with binding flags set according to `enablePrivate`.
         /// </summary>
         /// <param name="enablePrivate"></param>
-        public ResolutionContext(bool enablePrivate)
+        public ObjectGraphContext(bool enablePrivate)
         {
             BindingFlags = GetBindingFlags(enablePrivate);
-            VisitedTypes = new HashSet<Type>();
+            VisitedTypes = new List<Type>();
         }
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace Moq.AutoMock
         /// Used internally to track which types have been created inside a call graph,
         /// to detect cycles in the object graph.
         /// </summary>
-        public HashSet<Type> VisitedTypes { get; }
+        public List<Type> VisitedTypes { get; }
         
         private static BindingFlags GetBindingFlags(bool enablePrivate)
         {

--- a/Moq.AutoMock/ResolutionContext.cs
+++ b/Moq.AutoMock/ResolutionContext.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Moq.AutoMock
+{
+    /// <summary>
+    /// Handles state while creating an object graph.
+    /// </summary>
+    public class ResolutionContext
+    {
+        /// <summary>
+        /// Creates an instance with binding flags set according to `enablePrivate`.
+        /// </summary>
+        /// <param name="enablePrivate"></param>
+        public ResolutionContext(bool enablePrivate)
+        {
+            BindingFlags = GetBindingFlags(enablePrivate);
+            VisitedTypes = new HashSet<Type>();
+        }
+
+        /// <summary>
+        /// Flags passed to Mock constructor.
+        /// </summary>
+        public BindingFlags BindingFlags { get; }
+        
+        /// <summary>
+        /// Used internally to track which types have been created inside a call graph,
+        /// to detect cycles in the object graph.
+        /// </summary>
+        public HashSet<Type> VisitedTypes { get; }
+        
+        private static BindingFlags GetBindingFlags(bool enablePrivate)
+        {
+            var bindingFlags = BindingFlags.Instance | BindingFlags.Public;
+            if (enablePrivate) bindingFlags |= BindingFlags.NonPublic;
+            return bindingFlags;
+        }
+    }
+}

--- a/Moq.AutoMock/Resolvers/Array.cs
+++ b/Moq.AutoMock/Resolvers/Array.cs
@@ -1,0 +1,21 @@
+﻿namespace Moq.AutoMock.Resolvers
+{
+#if NET45
+    //Array.Empty does not exist in net45
+    //This duplicates what was added to .NET Core
+    internal static class Array
+    {
+        public static T[] Empty<T>()
+        {
+            return EmptyArray<T>.Value;
+        }
+
+        private static class EmptyArray<T>
+        {
+#pragma warning disable CA1825 // this is the implementation of Array.Empty<T>()
+            internal static readonly T[] Value = new T[0];
+#pragma warning restore CA1825
+        }
+    }
+#endif
+}

--- a/Moq.AutoMock/Resolvers/MockResolutionContext.cs
+++ b/Moq.AutoMock/Resolvers/MockResolutionContext.cs
@@ -17,7 +17,7 @@ namespace Moq.AutoMock.Resolvers
         /// Context within the object graph being created. This differs from the MockResolutionContext which is
         /// only relevant for a single object creation.
         /// </param>
-        public MockResolutionContext(AutoMocker autoMocker, Type requestType, object? initialValue, ResolutionContext objectGraphContext)
+        public MockResolutionContext(AutoMocker autoMocker, Type requestType, object? initialValue, ObjectGraphContext objectGraphContext)
         {
             AutoMocker = autoMocker ?? throw new ArgumentNullException(nameof(autoMocker));
             RequestType = requestType ?? throw new ArgumentNullException(nameof(requestType));
@@ -44,7 +44,7 @@ namespace Moq.AutoMock.Resolvers
         /// Context within the object graph being created. This differs from the MockResolutionContext which is
         /// only relevant for a single object creation.
         /// </summary>
-        public ResolutionContext ObjectGraphContext { get; }
+        public ObjectGraphContext ObjectGraphContext { get; }
 
         /// <summary>
         /// Deconstruct this instance into its individual properties.

--- a/Moq.AutoMock/Resolvers/MockResolutionContext.cs
+++ b/Moq.AutoMock/Resolvers/MockResolutionContext.cs
@@ -22,7 +22,7 @@ namespace Moq.AutoMock.Resolvers
             AutoMocker = autoMocker ?? throw new ArgumentNullException(nameof(autoMocker));
             RequestType = requestType ?? throw new ArgumentNullException(nameof(requestType));
             Value = initialValue;
-            ObjectGraphContext = objectGraphContext;
+            ObjectGraphContext = objectGraphContext ?? throw new ArgumentNullException(nameof(objectGraphContext));
         }
 
         /// <summary>

--- a/Moq.AutoMock/Resolvers/MockResolutionContext.cs
+++ b/Moq.AutoMock/Resolvers/MockResolutionContext.cs
@@ -13,11 +13,16 @@ namespace Moq.AutoMock.Resolvers
         /// <param name="autoMocker">The <c>AutoMocker</c> instance.</param>
         /// <param name="requestType">The requested type to resolve.</param>
         /// <param name="initialValue">The initial value to use.</param>
-        public MockResolutionContext(AutoMocker autoMocker, Type requestType, object? initialValue)
+        /// <param name="objectGraphContext">
+        /// Context within the object graph being created. This differs from the MockResolutionContext which is
+        /// only relevant for a single object creation.
+        /// </param>
+        public MockResolutionContext(AutoMocker autoMocker, Type requestType, object? initialValue, ResolutionContext objectGraphContext)
         {
             AutoMocker = autoMocker ?? throw new ArgumentNullException(nameof(autoMocker));
             RequestType = requestType ?? throw new ArgumentNullException(nameof(requestType));
             Value = initialValue;
+            ObjectGraphContext = objectGraphContext;
         }
 
         /// <summary>
@@ -34,6 +39,12 @@ namespace Moq.AutoMock.Resolvers
         /// The value to use from the resolution.
         /// </summary>
         public object? Value { get; set; }
+        
+        /// <summary>
+        /// Context within the object graph being created. This differs from the MockResolutionContext which is
+        /// only relevant for a single object creation.
+        /// </summary>
+        public ResolutionContext ObjectGraphContext { get; }
 
         /// <summary>
         /// Deconstruct this instance into its individual properties.

--- a/Moq.AutoMock/Resolvers/MockResolver.cs
+++ b/Moq.AutoMock/Resolvers/MockResolver.cs
@@ -44,7 +44,7 @@ namespace Moq.AutoMock.Resolvers
             object?[] constructorArgs;
             if (mayHaveDependencies)
             {
-                constructorArgs = context.AutoMocker.CreateArguments(context.RequestType);
+                constructorArgs = context.AutoMocker.CreateArguments(context.RequestType, context.ObjectGraphContext);
             }
             else
             {

--- a/Moq.AutoMock/Resolvers/MockResolver.cs
+++ b/Moq.AutoMock/Resolvers/MockResolver.cs
@@ -41,21 +41,17 @@ namespace Moq.AutoMock.Resolvers
             bool mayHaveDependencies = context.RequestType.IsClass
                                        && !typeof(Delegate).IsAssignableFrom(context.RequestType);
 
-            //Invoke the Mock<T>(MockBehavior, params object[]) constructor
-            object?[] constructorArgs = new object?[2];
-            constructorArgs[0] = _mockBehavior;
-
+            object?[] constructorArgs;
             if (mayHaveDependencies)
             {
-                constructorArgs[1] = context.AutoMocker.CreateArguments(context.RequestType);
+                constructorArgs = context.AutoMocker.CreateArguments(context.RequestType);
             }
             else
             {
-                // Compiler complains about empty array literal, but I can't find an alternative that will compile.
-                constructorArgs[1] = Array.Empty<object>();
+                constructorArgs = Array.Empty<object>();
             }
 
-            if (Activator.CreateInstance(mockType, constructorArgs) is Mock mock)
+            if (Activator.CreateInstance(mockType, _mockBehavior, constructorArgs) is Mock mock)
             {
                 mock.DefaultValue = _defaultValue;
                 mock.CallBase = _callBase;


### PR DESCRIPTION
Moq allows passing constructor args to mock instances via
`new Mock<Foo>(arg1, arg2, ...)`. This pull request enables doing this
for automocker, enhancing the "auto" part of "automocker".

Why do this? Because forcing every class to have an interface seems
unreasonable. Feel free to subscribe to whatever philosophy you prefer,
but the interface-to-class pairing does generate a lot of boilerplate.
Just as Moq allows as many scenarios as possible, Moq.Contrib should
also.