### PR TITLE
Update to C#9

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.404
+        dotnet-version: 5.0.100
 
   # Run unit tests
     - name: Test

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,17 +1,17 @@
 <Project>
 
  <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors Condition=" '$(BuildingForLiveUnitTesting)' == '' ">true</TreatWarningsAsErrors>
  </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="3.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="3.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Moq.AutoMock.Tests/Moq.AutoMock.Tests.csproj
+++ b/Moq.AutoMock.Tests/Moq.AutoMock.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Copyright>Copyright © 2020</Copyright>
 
     <IsPackable>false</IsPackable>

--- a/Moq.AutoMock/CastChecker.cs
+++ b/Moq.AutoMock/CastChecker.cs
@@ -8,7 +8,7 @@ namespace Moq.AutoMock
         public static bool DoesReturnPrimitive<TService>(Expression<Func<TService, object>> expression)
             where TService : class
         {
-            if (expression is null) throw new ArgumentNullException(nameof(expression));
+            _ = expression ?? throw new ArgumentNullException(nameof(expression));
 
             //expression is assumed to be a lambda so the cast here would cause an exception if it was not the expected format
             var lambdaExpression = (LambdaExpression)expression;

--- a/Moq.AutoMock/Extensions/TypeExtensions.cs
+++ b/Moq.AutoMock/Extensions/TypeExtensions.cs
@@ -14,7 +14,7 @@ namespace Moq.AutoMock.Extensions
             @delegate = null;
             var stInfo = funcType.GetTypeInfo();
             if (!typeof(Delegate).IsAssignableFrom(funcType)
-                || !stInfo.IsGenericType || !(funcType.GetGenericTypeDefinition() is Type td)
+                || !stInfo.IsGenericType || funcType.GetGenericTypeDefinition() is not Type td
                 || td.Namespace != nameof(System) || !Regex.IsMatch(td.Name, $"^{nameof(Func<object>)}\\b"))
                 return false;
 

--- a/Moq.AutoMock/Moq.AutoMock.csproj
+++ b/Moq.AutoMock/Moq.AutoMock.csproj
@@ -41,7 +41,7 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>AutoMocker.Combine.cs.generated.cs</LastGenOutput>
     </None>
-    <Compile Include="..\System.Diagnostics.CodeAnalysis.cs" Condition=" '$(TargetFramework)' != 'net5.0' " />
+    <Compile Include="..\System.Diagnostics.CodeAnalysis.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Moq.AutoMock/Moq.AutoMock.csproj
+++ b/Moq.AutoMock/Moq.AutoMock.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0;net5.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <Copyright>Copyright © $([System.DateTime]::UtcNow.ToString("yyyy"))</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
@@ -41,7 +41,7 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>AutoMocker.Combine.cs.generated.cs</LastGenOutput>
     </None>
-    <Compile Include="..\System.Diagnostics.CodeAnalysis.cs" />
+    <Compile Include="..\System.Diagnostics.CodeAnalysis.cs" Condition=" '$(TargetFramework)' != 'net5.0' " />
   </ItemGroup>
 
   <ItemGroup>

--- a/Moq.AutoMock/Moq.AutoMock.csproj
+++ b/Moq.AutoMock/Moq.AutoMock.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <Copyright>Copyright © $([System.DateTime]::UtcNow.ToString("yyyy"))</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/Moq.AutoMock/Resolvers/MockResolver.cs
+++ b/Moq.AutoMock/Resolvers/MockResolver.cs
@@ -41,15 +41,9 @@ namespace Moq.AutoMock.Resolvers
             bool mayHaveDependencies = context.RequestType.IsClass
                                        && !typeof(Delegate).IsAssignableFrom(context.RequestType);
 
-            object?[] constructorArgs;
-            if (mayHaveDependencies)
-            {
-                constructorArgs = context.AutoMocker.CreateArguments(context.RequestType, context.ObjectGraphContext);
-            }
-            else
-            {
-                constructorArgs = Array.Empty<object>();
-            }
+            object?[] constructorArgs = mayHaveDependencies
+                ? context.AutoMocker.CreateArguments(context.RequestType, context.ObjectGraphContext)
+                : Array.Empty<object>();
 
             if (Activator.CreateInstance(mockType, _mockBehavior, constructorArgs) is Mock mock)
             {

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+      "version": "5.0.100",
+      "rollForward": "latestMajor"
+    }
+}


### PR DESCRIPTION
The guidance as I understand it is that library authors don't need to add .NET5 unless they have a reason to do it. I put it in here because @Keboo has been asking for it, but the .netstandard2.0 target is sufficient.

I'm not sure on version bump with the SDK change though. Any insight?