### PR TITLE
Expose `enablePrivate` on Get/GetMock

### DIFF
--- a/Moq.AutoMock.Tests/DescribeGetMock.cs
+++ b/Moq.AutoMock.Tests/DescribeGetMock.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq.AutoMock.Tests.Util;
 
 namespace Moq.AutoMock.Tests
@@ -36,6 +37,39 @@ namespace Moq.AutoMock.Tests
             var mocker = new AutoMocker();
             Mock<Empty>? mock = mocker.GetMock(typeof(Empty)) as Mock<Empty>;
             Assert.IsNotNull(mock);
+        }
+
+
+        [TestMethod]
+        public void It_fails_mocking_abstract_with_protected_ctor()
+        {
+            var mocker = new AutoMocker();
+            Assert.ThrowsException<ArgumentException>(() => mocker.GetMock<ProtectedConstructor>());
+        }
+
+        [TestMethod]
+        public void It_allows_protected_abstract_mock_when_overriden()
+        {
+            var mocker = new AutoMocker();
+            var mock = mocker.GetMock<ProtectedConstructor>(enablePrivate: true);
+            Assert.IsNotNull(mock);
+            Assert.IsInstanceOfType(mock.Object, typeof(ProtectedConstructor));
+        }
+
+        [TestMethod]
+        public void It_fails_getting_mocked_object_with_protected_ctor()
+        {
+            var mocker = new AutoMocker();
+            Assert.ThrowsException<ArgumentException>(() => mocker.Get<ProtectedConstructor>());
+        }
+
+        [TestMethod]
+        public void It_allows_getting_mocked_object_when_overriden()
+        {
+            var mocker = new AutoMocker();
+            var @protected = mocker.Get<ProtectedConstructor>(enablePrivate: true);
+            Assert.IsNotNull(@protected);
+            Assert.IsInstanceOfType(@protected, typeof(ProtectedConstructor));
         }
     }
 }

--- a/Moq.AutoMock.Tests/Util/ProtectedConstructor.cs
+++ b/Moq.AutoMock.Tests/Util/ProtectedConstructor.cs
@@ -1,0 +1,7 @@
+﻿namespace Moq.AutoMock.Tests.Util
+{
+    public abstract class ProtectedConstructor
+    {
+        protected ProtectedConstructor() { }
+    }
+}

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -146,7 +146,7 @@ namespace Moq.AutoMock
         /// mocks.
         /// </summary>
         /// <typeparam name="T">A concrete type</typeparam>
-        /// <param name="enablePrivate">When true, private constructors will also be used to create mocks.</param>
+        /// <param name="enablePrivate">When true, non-public constructors will also be used to create mocks.</param>
         /// <returns>An instance of T with all constructor arguments derived from services 
         /// setup in the container.</returns>
         public T CreateInstance<T>(bool enablePrivate) where T : class
@@ -168,7 +168,7 @@ namespace Moq.AutoMock
         /// mocks.
         /// </summary>
         /// <param name="type">A concrete type</param>
-        /// <param name="enablePrivate">When true, private constructors will also be used to create mocks.</param>
+        /// <param name="enablePrivate">When true, non-public constructors will also be used to create mocks.</param>
         /// <returns>An instance of type with all constructor arguments derived from services 
         /// setup in the container.</returns>
         public object CreateInstance(Type type, bool enablePrivate)
@@ -207,7 +207,7 @@ namespace Moq.AutoMock
         /// abstract classes, or avoiding breaking cohesion even further with a non-abstract class.
         /// </summary>
         /// <typeparam name="T">The instance that you want to build</typeparam>
-        /// <param name="enablePrivate">When true, private constructors will also be used to create mocks.</param>
+        /// <param name="enablePrivate">When true, non-public constructors will also be used to create mocks.</param>
         /// <returns>An instance with virtual and abstract members mocked</returns>
         public T CreateSelfMock<T>(bool enablePrivate) where T : class?
         {
@@ -299,7 +299,7 @@ namespace Moq.AutoMock
         /// a service setup explicitly via `.Use()` or implicitly with `.CreateInstance()`.
         /// </summary>
         /// <typeparam name="TService">The class or interface to search on</typeparam>
-        /// <param name="enablePrivate">When true, private constructors will also be used to create mocks.</param>
+        /// <param name="enablePrivate">When true, non-public constructors will also be used to create mocks.</param>
         /// <returns>The object that implements TService</returns>
         public TService Get<TService>(bool enablePrivate) where TService : class?
         {
@@ -325,7 +325,7 @@ namespace Moq.AutoMock
         /// a service setup explicitly via `.Use()` or implicitly with `.CreateInstance()`.
         /// </summary>
         /// <param name="serviceType">The type of service to retrieve</param>
-        /// <param name="enablePrivate">When true, private constructors will also be used to create mocks.</param>
+        /// <param name="enablePrivate">When true, non-public constructors will also be used to create mocks.</param>
         /// <returns></returns>
         public object Get(Type serviceType, bool enablePrivate)
         {
@@ -361,7 +361,7 @@ namespace Moq.AutoMock
         /// Searches and retrieves the mock that the container uses for TService.
         /// </summary>
         /// <typeparam name="TService">The class or interface to search on</typeparam>
-        /// <param name="enablePrivate">When true, private constructors will also be used to create mocks.</param>
+        /// <param name="enablePrivate">When true, non-public constructors will also be used to create mocks.</param>
         /// <exception cref="ArgumentException">if the requested object wasn't a Mock</exception>
         /// <returns>A mock of TService</returns>
         public Mock<TService> GetMock<TService>(bool enablePrivate) where TService : class
@@ -383,7 +383,7 @@ namespace Moq.AutoMock
         /// Searches and retrieves the mock that the container uses for serviceType.
         /// </summary>
         /// <param name="serviceType">The type of service to retrieve</param>
-        /// <param name="enablePrivate">When true, private constructors will also be used to create mocks.</param>
+        /// <param name="enablePrivate">When true, non-public constructors will also be used to create mocks.</param>
         /// <returns>A mock of serviceType</returns>
         public Mock GetMock(Type serviceType, bool enablePrivate)
         {

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -146,8 +146,7 @@ namespace Moq.AutoMock
         /// mocks.
         /// </summary>
         /// <typeparam name="T">A concrete type</typeparam>
-        /// <param name="enablePrivate">When true, private constructors will also be used to
-        /// create mocks.</param>
+        /// <param name="enablePrivate">When true, private constructors will also be used to create mocks.</param>
         /// <returns>An instance of T with all constructor arguments derived from services 
         /// setup in the container.</returns>
         public T CreateInstance<T>(bool enablePrivate) where T : class
@@ -169,8 +168,7 @@ namespace Moq.AutoMock
         /// mocks.
         /// </summary>
         /// <param name="type">A concrete type</param>
-        /// <param name="enablePrivate">When true, private constructors will also be used to
-        /// create mocks.</param>
+        /// <param name="enablePrivate">When true, private constructors will also be used to create mocks.</param>
         /// <returns>An instance of type with all constructor arguments derived from services 
         /// setup in the container.</returns>
         public object CreateInstance(Type type, bool enablePrivate)
@@ -209,8 +207,7 @@ namespace Moq.AutoMock
         /// abstract classes, or avoiding breaking cohesion even further with a non-abstract class.
         /// </summary>
         /// <typeparam name="T">The instance that you want to build</typeparam>
-        /// <param name="enablePrivate">When true, private constructors will also be used to
-        /// create mocks.</param>
+        /// <param name="enablePrivate">When true, private constructors will also be used to create mocks.</param>
         /// <returns>An instance with virtual and abstract members mocked</returns>
         public T CreateSelfMock<T>(bool enablePrivate) where T : class?
         {
@@ -298,6 +295,21 @@ namespace Moq.AutoMock
         }
 
         /// <summary>
+        /// Searches and retrieves an object from the container that matches TService. This can be
+        /// a service setup explicitly via `.Use()` or implicitly with `.CreateInstance()`.
+        /// </summary>
+        /// <typeparam name="TService">The class or interface to search on</typeparam>
+        /// <param name="enablePrivate">When true, private constructors will also be used to create mocks.</param>
+        /// <returns>The object that implements TService</returns>
+        public TService Get<TService>(bool enablePrivate) where TService : class?
+        {
+            if (Get(typeof(TService), enablePrivate) is TService service)
+                return service;
+
+            return null!;
+        }
+
+        /// <summary>
         /// Searches and retrieves an object from the container that matches the serviceType. This can be
         /// a service setup explicitly via `.Use()` or implicitly with `.CreateInstance()`.
         /// </summary>
@@ -305,7 +317,19 @@ namespace Moq.AutoMock
         /// <returns></returns>
         public object Get(Type serviceType)
         {
-            return Get(serviceType, new ObjectGraphContext(false));
+            return Get(serviceType, enablePrivate: false);
+        }
+
+        /// <summary>
+        /// Searches and retrieves an object from the container that matches the serviceType. This can be
+        /// a service setup explicitly via `.Use()` or implicitly with `.CreateInstance()`.
+        /// </summary>
+        /// <param name="serviceType">The type of service to retrieve</param>
+        /// <param name="enablePrivate">When true, private constructors will also be used to create mocks.</param>
+        /// <returns></returns>
+        public object Get(Type serviceType, bool enablePrivate)
+        {
+            return Get(serviceType, new ObjectGraphContext(enablePrivate));
         }
         
         private object Get(Type serviceType, ObjectGraphContext context)
@@ -331,7 +355,17 @@ namespace Moq.AutoMock
         /// <exception cref="ArgumentException">if the requested object wasn't a Mock</exception>
         /// <returns>A mock of TService</returns>
         public Mock<TService> GetMock<TService>() where TService : class
-            => (Mock<TService>)GetMockImplementation(typeof(TService));
+            => (Mock<TService>)GetMock(typeof(TService));
+
+        /// <summary>
+        /// Searches and retrieves the mock that the container uses for TService.
+        /// </summary>
+        /// <typeparam name="TService">The class or interface to search on</typeparam>
+        /// <param name="enablePrivate">When true, private constructors will also be used to create mocks.</param>
+        /// <exception cref="ArgumentException">if the requested object wasn't a Mock</exception>
+        /// <returns>A mock of TService</returns>
+        public Mock<TService> GetMock<TService>(bool enablePrivate) where TService : class
+            => (Mock<TService>)GetMock(typeof(TService), enablePrivate);
 
         /// <summary>
         /// Searches and retrieves the mock that the container uses for serviceType.
@@ -342,13 +376,26 @@ namespace Moq.AutoMock
         {
             if (serviceType is null) throw new ArgumentNullException(nameof(serviceType));
 
-            return GetMockImplementation(serviceType);
+            return GetMock(serviceType, enablePrivate: false);
         }
 
-        private Mock GetMockImplementation(Type serviceType)
+        /// <summary>
+        /// Searches and retrieves the mock that the container uses for serviceType.
+        /// </summary>
+        /// <param name="serviceType">The type of service to retrieve</param>
+        /// <param name="enablePrivate">When true, private constructors will also be used to create mocks.</param>
+        /// <returns>A mock of serviceType</returns>
+        public Mock GetMock(Type serviceType, bool enablePrivate)
+        {
+            if (serviceType is null) throw new ArgumentNullException(nameof(serviceType));
+
+            return GetMockImplementation(serviceType, enablePrivate);
+        }
+
+        private Mock GetMockImplementation(Type serviceType, bool enablePrivate)
         {
             if (!_typeMap.TryGetValue(serviceType, out var instance) || instance is null)
-                instance = _typeMap[serviceType] = Resolve(serviceType, new ObjectGraphContext(false));
+                instance = _typeMap[serviceType] = Resolve(serviceType, new ObjectGraphContext(enablePrivate));
 
             if (instance == null || !instance.IsMock)
                 throw new ArgumentException($"Registered service `{Get(serviceType)?.GetType()}` was not a mock");

--- a/Moq.AutoMock/Moq.AutoMock.csproj
+++ b/Moq.AutoMock/Moq.AutoMock.csproj
@@ -6,7 +6,7 @@
     <Copyright>Copyright © $([System.DateTime]::UtcNow.ToString("yyyy"))</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
 
-    <VersionPrefix Condition=" '$(VersionPrefix)' == '' ">2.1.0</VersionPrefix>
+    <VersionPrefix Condition=" '$(VersionPrefix)' == '' ">2.1.1</VersionPrefix>
     <VersionPrefix Condition=" '$(Revision)' != '' ">$(VersionPrefix).$(Revision)</VersionPrefix>
 
     <Authors>Tim Kellogg, Adam Hewitt, Kevin Bost</Authors>

--- a/Moq.AutoMock/Moq.AutoMock.csproj
+++ b/Moq.AutoMock/Moq.AutoMock.csproj
@@ -6,7 +6,7 @@
     <Copyright>Copyright © $([System.DateTime]::UtcNow.ToString("yyyy"))</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
 
-    <VersionPrefix Condition=" '$(VersionPrefix)' == '' ">2.1.1</VersionPrefix>
+    <VersionPrefix Condition=" '$(VersionPrefix)' == '' ">2.2.0</VersionPrefix>
     <VersionPrefix Condition=" '$(Revision)' != '' ">$(VersionPrefix).$(Revision)</VersionPrefix>
 
     <Authors>Tim Kellogg, Adam Hewitt, Kevin Bost</Authors>


### PR DESCRIPTION
Addresses #88, allows the caller to override the filter. I don't necessarily love this architecturally, but we already have the precedence on `CreateInstance` and so it makes sense here for consistency.