### PR TITLE
Create SetupWithAny extension

### DIFF
--- a/Moq.AutoMock.Tests/DescribeSetupAll.cs
+++ b/Moq.AutoMock.Tests/DescribeSetupAll.cs
@@ -13,7 +13,7 @@ namespace Moq.AutoMock.Tests
             string expected = "SomeValue";
             Mock<IService4> mock = new();
 
-            mock.SetupAll<IService4, string>(nameof(IService4.MainMethodName))
+            mock.SetupWithAny<IService4, string>(nameof(IService4.MainMethodName))
                 .Returns(expected);
 
             string result = mock.Object.MainMethodName("Something");
@@ -26,7 +26,7 @@ namespace Moq.AutoMock.Tests
         {
             Mock<IService6> mock = new();
 
-            mock.SetupAll(nameof(IService6.Void))
+            mock.SetupWithAny(nameof(IService6.Void))
                 .Verifiable();
             
             mock.Object.Void(42, "SomeValue");

--- a/Moq.AutoMock.Tests/DescribeSetupAll.cs
+++ b/Moq.AutoMock.Tests/DescribeSetupAll.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq.AutoMock.Tests.Util;
+using System;
+
+namespace Moq.AutoMock.Tests
+{
+    [TestClass]
+    public class DescribeSetupAll
+    {
+        [TestMethod]
+        public void You_can_setup_all_on_a_method_with_a_return_value()
+        {
+            string expected = "SomeValue";
+            Mock<IService4> mock = new();
+
+            mock.SetupAll<IService4, string>(nameof(IService4.MainMethodName))
+                .Returns(expected);
+
+            string result = mock.Object.MainMethodName("Something");
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public void You_can_setup_all_on_a_void_method()
+        {
+            Mock<IService6> mock = new();
+
+            mock.SetupAll(nameof(IService6.Void))
+                .Verifiable();
+            
+            mock.Object.Void(42, "SomeValue");
+
+            mock.VerifyAll();
+        }
+    }
+}

--- a/Moq.AutoMock.Tests/DescribeSetupWithAny.cs
+++ b/Moq.AutoMock.Tests/DescribeSetupWithAny.cs
@@ -5,7 +5,7 @@ using System;
 namespace Moq.AutoMock.Tests
 {
     [TestClass]
-    public class DescribeSetupAll
+    public class DescribeSetupWithAny
     {
         [TestMethod]
         public void You_can_setup_all_on_a_method_with_a_return_value()
@@ -33,5 +33,24 @@ namespace Moq.AutoMock.Tests
 
             mock.VerifyAll();
         }
+
+        [TestMethod]
+        public void When_method_is_not_found_it_throws()
+        {
+            Mock<IService1> mock = new();
+
+            string expectedMessage = 
+                new MissingMethodException(typeof(IService1).Name, "Unknown Method").Message;
+            try
+            {
+                mock.SetupWithAny("Unknown Method");
+
+            }
+            catch (MissingMethodException ex) 
+                when (ex.Message == expectedMessage)
+            { }
+        }
+
+
     }
 }

--- a/Moq.AutoMock.Tests/DescribeSetupWithAny.cs
+++ b/Moq.AutoMock.Tests/DescribeSetupWithAny.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq.AutoMock.Tests.Util;
 using System;
+using System.Reflection;
 
 namespace Moq.AutoMock.Tests
 {
@@ -51,6 +52,80 @@ namespace Moq.AutoMock.Tests
             { }
         }
 
+        [TestMethod]
+        [ExpectedException(typeof(AmbiguousMatchException))]
+        public void When_void_method_is_overloaded_it_throws()
+        {
+            Mock<IService7> mock = new();
 
+            mock.SetupWithAny(nameof(IService7.Void));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(AmbiguousMatchException))]
+        public void When_method_is_overloaded_it_throws()
+        {
+            Mock<IService7> mock = new();
+
+            mock.SetupWithAny(nameof(IService7.ReturnValue));
+        }
+
+        [TestMethod]
+        public void You_can_setup_all_on_a_method_with_a_return_value_using_AutoMocker()
+        {
+            string expected = "SomeValue";
+            AutoMocker mocker = new();
+
+            mocker.SetupWithAny<IService4, string>(nameof(IService4.MainMethodName))
+                .Returns(expected);
+
+            string result = mocker.Get<IService4>().MainMethodName("Something");
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public void You_can_setup_all_on_a_method_with_a_return_value_using_AutoMocker_with_cached_mock()
+        {
+            string expected = "SomeValue";
+            AutoMocker mocker = new();
+            Mock<IService4> mock = new();
+            mocker.Use(mock);
+
+            mocker.SetupWithAny<IService4, string>(nameof(IService4.MainMethodName))
+                .Returns(expected);
+
+            string result = mock.Object.MainMethodName("Something");
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public void You_can_setup_all_on_a_void_method_using_AutoMocker()
+        {
+            AutoMocker mocker = new();
+
+            mocker.SetupWithAny<IService6>(nameof(IService6.Void))
+                .Verifiable();
+
+            mocker.Get<IService6>().Void(42, "SomeValue");
+
+            mocker.VerifyAll();
+        }
+
+        [TestMethod]
+        public void You_can_setup_all_on_a_void_method_using_AutoMocker_with_cached_mock()
+        {
+            AutoMocker mocker = new();
+            Mock<IService6> mock = new();
+            mocker.Use(mock);
+
+            mocker.SetupWithAny<IService6>(nameof(IService6.Void))
+                .Verifiable();
+
+            mock.Object.Void(42, "SomeValue");
+
+            mock.VerifyAll();
+        }
     }
 }

--- a/Moq.AutoMock.Tests/DescribeSetupWithAny.cs
+++ b/Moq.AutoMock.Tests/DescribeSetupWithAny.cs
@@ -9,7 +9,7 @@ namespace Moq.AutoMock.Tests
     public class DescribeSetupWithAny
     {
         [TestMethod]
-        public void You_can_setup_all_on_a_method_with_a_return_value()
+        public void You_can_setup_with_any_on_a_method_with_a_return_value()
         {
             string expected = "SomeValue";
             Mock<IService4> mock = new();
@@ -23,7 +23,7 @@ namespace Moq.AutoMock.Tests
         }
 
         [TestMethod]
-        public void You_can_setup_all_on_a_void_method()
+        public void You_can_setup_with_any_on_a_void_method()
         {
             Mock<IService6> mock = new();
 
@@ -71,7 +71,7 @@ namespace Moq.AutoMock.Tests
         }
 
         [TestMethod]
-        public void You_can_setup_all_on_a_method_with_a_return_value_using_AutoMocker()
+        public void You_can_setup_with_any_on_a_method_with_a_return_value_using_AutoMocker()
         {
             string expected = "SomeValue";
             AutoMocker mocker = new();
@@ -85,7 +85,7 @@ namespace Moq.AutoMock.Tests
         }
 
         [TestMethod]
-        public void You_can_setup_all_on_a_method_with_a_return_value_using_AutoMocker_with_cached_mock()
+        public void You_can_setup_with_any_on_a_method_with_a_return_value_using_AutoMocker_with_cached_mock()
         {
             string expected = "SomeValue";
             AutoMocker mocker = new();
@@ -101,7 +101,7 @@ namespace Moq.AutoMock.Tests
         }
 
         [TestMethod]
-        public void You_can_setup_all_on_a_void_method_using_AutoMocker()
+        public void You_can_setup_with_any_on_a_void_method_using_AutoMocker()
         {
             AutoMocker mocker = new();
 
@@ -114,7 +114,7 @@ namespace Moq.AutoMock.Tests
         }
 
         [TestMethod]
-        public void You_can_setup_all_on_a_void_method_using_AutoMocker_with_cached_mock()
+        public void You_can_setup_with_any_on_a_void_method_using_AutoMocker_with_cached_mock()
         {
             AutoMocker mocker = new();
             Mock<IService6> mock = new();

--- a/Moq.AutoMock.Tests/Util/IService6.cs
+++ b/Moq.AutoMock.Tests/Util/IService6.cs
@@ -1,0 +1,7 @@
+﻿namespace Moq.AutoMock.Tests.Util
+{
+    public interface IService6
+    {
+        void Void(int value, string otherValue);
+    }
+}

--- a/Moq.AutoMock.Tests/Util/IService7.cs
+++ b/Moq.AutoMock.Tests/Util/IService7.cs
@@ -1,0 +1,11 @@
+﻿namespace Moq.AutoMock.Tests.Util
+{
+    public interface IService7
+    {
+        void Void(int value);
+        void Void(string value);
+
+        object ReturnValue(int value);
+        object ReturnValue(string value);
+    }
+}

--- a/Moq.AutoMock.sln
+++ b/Moq.AutoMock.sln
@@ -10,6 +10,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5698188E-884A-49D3-A74B-FF98C782BF15}"
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
+		.github\workflows\dotnetcore.yml = .github\workflows\dotnetcore.yml
 		LICENSE.md = LICENSE.md
 		README.md = README.md
 	EndProjectSection

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -436,6 +436,41 @@ namespace Moq.AutoMock
             return Setup<ISetup<TService, TReturn>, TService>(m => m.Setup(setup));
         }
 
+        /// <summary>
+        /// Specifies a setup on the mocked type for a call to a void method.
+        /// All parameters are filled with <see cref ="It.IsAny" /> according to the parameter's type.
+        /// </summary>
+        /// <remarks>
+        /// This may only be used on methods that are not overloaded.
+        /// This will create the mock when necessary.
+        /// </remarks>
+        /// <typeparam name="TService">The service type</typeparam>
+        /// <param name="methodName">The name of the expected method invocation.</param>
+        /// <returns></returns>
+        public ISetup<TService> SetupWithAny<TService>(string methodName)
+            where TService : class
+        {
+            return Setup<ISetup<TService>, TService>(m => m.SetupWithAny(methodName));
+        }
+
+        /// <summary>
+        /// Specifies a setup on the mocked type for a call to a non-void (value-returning) method.
+        /// All parameters are filled with <see cref ="It.IsAny" /> according to the parameter's type.
+        /// </summary>
+        /// <remarks>
+        /// This may only be used on methods that are not overloaded.
+        /// This will create the mock when necessary.
+        /// </remarks>
+        /// <typeparam name="TService">The service type</typeparam>
+        /// <typeparam name="TReturn">The return type of the method</typeparam>
+        /// <param name="methodName">The name of the expected method invocation.</param>
+        /// <returns></returns>
+        public ISetup<TService, TReturn> SetupWithAny<TService, TReturn>(string methodName)
+            where TService : class
+        {
+            return Setup<ISetup<TService, TReturn>, TService>(m => m.SetupWithAny<TService, TReturn>(methodName));
+        }
+
         private TReturn Setup<TReturn, TService>(Func<Mock<TService>, TReturn> returnValue)
             where TService : class
         {

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -446,6 +446,9 @@ namespace Moq.AutoMock
         /// </remarks>
         /// <typeparam name="TService">The service type</typeparam>
         /// <param name="methodName">The name of the expected method invocation.</param>
+        /// <exception cref="ArgumentNullException">When the methodName is null.</exception>
+        /// <exception cref="MissingMethodException">Thrown when no method with methodName is found.</exception>
+        /// <exception cref="AmbiguousMatchException">Thrown when more that one method matches the passed method name.</exception>
         /// <returns></returns>
         public ISetup<TService> SetupWithAny<TService>(string methodName)
             where TService : class
@@ -464,6 +467,9 @@ namespace Moq.AutoMock
         /// <typeparam name="TService">The service type</typeparam>
         /// <typeparam name="TReturn">The return type of the method</typeparam>
         /// <param name="methodName">The name of the expected method invocation.</param>
+        /// <exception cref="ArgumentNullException">When the methodName is null.</exception>
+        /// <exception cref="MissingMethodException">Thrown when no method with methodName is found.</exception>
+        /// <exception cref="AmbiguousMatchException">Thrown when more that one method matches the passed method name.</exception>
         /// <returns></returns>
         public ISetup<TService, TReturn> SetupWithAny<TService, TReturn>(string methodName)
             where TService : class

--- a/Moq.AutoMock/MockExtensions.cs
+++ b/Moq.AutoMock/MockExtensions.cs
@@ -12,13 +12,13 @@ namespace Moq.AutoMock
     public static class MockExtensions
     {
         /// <summary>
-        /// Specifies a setup on the mocked type for a call to a non-void (value-returning) method.
+        /// Specifies a setup on the mocked type for a call to a void method. 
         /// All parameters are filled with <see cref ="It.IsAny" /> according to the parameter's type.
         /// </summary>
         /// <remarks>
         /// This may only be used on methods that are not overloaded.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="T">Type of the mock</typeparam>
         /// <param name="mock">The mock</param>
         /// <param name="methodName">The name of the expected method invocation.</param>
         /// <returns></returns>
@@ -30,6 +30,11 @@ namespace Moq.AutoMock
                 throw new ArgumentNullException(nameof(mock));
             }
 
+            if (methodName is null)
+            {
+                throw new ArgumentNullException(nameof(methodName));
+            }
+
             LambdaExpression lambdaExpression = GetExpression<T>(methodName);
 
             MethodInfo setupMethod = mock.GetType().GetMethods()
@@ -38,15 +43,15 @@ namespace Moq.AutoMock
         }
 
         /// <summary>
-        /// Specifies a setup on the mocked type for a call to a void method. 
+        /// Specifies a setup on the mocked type for a call to a non-void (value-returning) method. 
         /// All parameters are filled with <see cref ="It.IsAny" /> according to the parameter's type.
         /// </summary>
         /// <remarks>
         /// This may only be used on methods that are not overloaded.
         /// </remarks>
-        /// <typeparam name="T"></typeparam>
-        /// <typeparam name="TResult"></typeparam>
-        /// <param name="mock"></param>
+        /// <typeparam name="T">Type of the mock</typeparam>
+        /// <typeparam name="TResult">The return type of the method</typeparam>
+        /// <param name="mock">The mock</param>
         /// <param name="methodName">The name of the expected method invocation.</param>
         /// <returns></returns>
         public static ISetup<T, TResult> SetupWithAny<T, TResult>(this Mock<T> mock, string methodName)
@@ -55,6 +60,11 @@ namespace Moq.AutoMock
             if (mock is null)
             {
                 throw new ArgumentNullException(nameof(mock));
+            }
+
+            if (methodName is null)
+            {
+                throw new ArgumentNullException(nameof(methodName));
             }
 
             LambdaExpression lambdaExpression = GetExpression<T>(methodName);

--- a/Moq.AutoMock/MockExtensions.cs
+++ b/Moq.AutoMock/MockExtensions.cs
@@ -89,7 +89,7 @@ namespace Moq.AutoMock
             {
                 0 => throw new MissingMethodException(typeof(T).Name, methodName),
                 1 => matchingMethods[0],
-                _ => throw new AmbiguousMatchException($"Cannot create a Setup on method '{methodName}'. {nameof(SetupWithAny)} does nto support methods with multiple overloads."),
+                _ => throw new AmbiguousMatchException($"Cannot create a Setup on method '{methodName}'. {nameof(SetupWithAny)} does not support methods with multiple overloads."),
             };
 
 

--- a/Moq.AutoMock/MockExtensions.cs
+++ b/Moq.AutoMock/MockExtensions.cs
@@ -12,13 +12,17 @@ namespace Moq.AutoMock
     public static class MockExtensions
     {
         /// <summary>
-        /// TODO
+        /// Specifies a setup on the mocked type for a call to a non-void (value-returning) method.
+        /// All parameters are filled with <see cref ="It.IsAny" /> according to the parameter's type.
         /// </summary>
+        /// <remarks>
+        /// This may only be used on methods that are not overloaded.
+        /// </remarks>
         /// <typeparam name="T"></typeparam>
-        /// <param name="mock"></param>
-        /// <param name="methodName"></param>
+        /// <param name="mock">The mock</param>
+        /// <param name="methodName">The name of the expected method invocation.</param>
         /// <returns></returns>
-        public static ISetup<T> SetupAll<T>(this Mock<T> mock, string methodName)
+        public static ISetup<T> SetupWithAny<T>(this Mock<T> mock, string methodName)
             where T : class
         {
             if (mock is null)
@@ -34,14 +38,18 @@ namespace Moq.AutoMock
         }
 
         /// <summary>
-        /// TODO
+        /// Specifies a setup on the mocked type for a call to a void method. 
+        /// All parameters are filled with <see cref ="It.IsAny" /> according to the parameter's type.
         /// </summary>
+        /// <remarks>
+        /// This may only be used on methods that are not overloaded.
+        /// </remarks>
         /// <typeparam name="T"></typeparam>
         /// <typeparam name="TResult"></typeparam>
         /// <param name="mock"></param>
-        /// <param name="methodName"></param>
+        /// <param name="methodName">The name of the expected method invocation.</param>
         /// <returns></returns>
-        public static ISetup<T, TResult> SetupAll<T, TResult>(this Mock<T> mock, string methodName)
+        public static ISetup<T, TResult> SetupWithAny<T, TResult>(this Mock<T> mock, string methodName)
             where T : class
         {
             if (mock is null)
@@ -62,9 +70,9 @@ namespace Moq.AutoMock
         {
             //Build up the expression to pass to the Setup method
             MethodInfo method = typeof(T).GetMethod(methodName)!;
-            if (method is null) throw new Exception("Boom");
+            if (method is null) throw new MissingMethodException(typeof(T).Name, methodName);
 
-            var itType = typeof(Moq.It);
+            var itType = typeof(It);
             var isAnyMethod = itType.GetMethod(nameof(It.IsAny));
 
             var parameterExpressions = method.GetParameters()

--- a/Moq.AutoMock/MockExtensions.cs
+++ b/Moq.AutoMock/MockExtensions.cs
@@ -1,0 +1,84 @@
+﻿using Moq.Language.Flow;
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Moq.AutoMock
+{
+    /// <summary>
+    /// TODO
+    /// </summary>
+    public static class MockExtensions
+    {
+        /// <summary>
+        /// TODO
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="mock"></param>
+        /// <param name="methodName"></param>
+        /// <returns></returns>
+        public static ISetup<T> SetupAll<T>(this Mock<T> mock, string methodName)
+            where T : class
+        {
+            if (mock is null)
+            {
+                throw new ArgumentNullException(nameof(mock));
+            }
+
+            LambdaExpression lambdaExpression = GetExpression<T>(methodName);
+
+            MethodInfo setupMethod = mock.GetType().GetMethods()
+                .Single(x => x.Name == nameof(Mock<object>.Setup) && x.ReturnType.GetGenericArguments().Length == 1);
+            return (ISetup<T>)setupMethod.Invoke(mock, new object[] { lambdaExpression })!;
+        }
+
+        /// <summary>
+        /// TODO
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        /// <param name="mock"></param>
+        /// <param name="methodName"></param>
+        /// <returns></returns>
+        public static ISetup<T, TResult> SetupAll<T, TResult>(this Mock<T> mock, string methodName)
+            where T : class
+        {
+            if (mock is null)
+            {
+                throw new ArgumentNullException(nameof(mock));
+            }
+
+            LambdaExpression lambdaExpression = GetExpression<T>(methodName);
+
+            //Invoke the setup method
+            MethodInfo setupMethod = mock.GetType().GetMethods()
+                .Single(x => x.Name == nameof(Mock<object>.Setup) && x.ReturnType.GetGenericArguments().Length == 2);
+            var ret = setupMethod.MakeGenericMethod(typeof(TResult)).Invoke(mock, new object[] { lambdaExpression });
+            return (ISetup<T, TResult>)ret!;
+        }
+
+        private static LambdaExpression GetExpression<T>(string methodName)
+        {
+            //Build up the expression to pass to the Setup method
+            MethodInfo method = typeof(T).GetMethod(methodName)!;
+            if (method is null) throw new Exception("Boom");
+
+            var itType = typeof(Moq.It);
+            var isAnyMethod = itType.GetMethod(nameof(It.IsAny));
+
+            var parameterExpressions = method.GetParameters()
+                .Select(parameter =>
+                {
+                    var closeAnyMethod = isAnyMethod!.MakeGenericMethod(parameter.ParameterType);
+                    return Expression.Call(null, closeAnyMethod);
+                })
+                .ToArray();
+
+            var xExpression = Expression.Parameter(typeof(T), "x");
+            var methodCallExpression = Expression.Call(xExpression, method, parameterExpressions);
+            return Expression.Lambda(methodCallExpression, false, new[] { xExpression });
+        }
+    }
+
+}

--- a/Moq.AutoMock/MockExtensions.cs
+++ b/Moq.AutoMock/MockExtensions.cs
@@ -21,6 +21,9 @@ namespace Moq.AutoMock
         /// <typeparam name="T">Type of the mock</typeparam>
         /// <param name="mock">The mock</param>
         /// <param name="methodName">The name of the expected method invocation.</param>
+        /// <exception cref="ArgumentNullException">When mock or methodName is null.</exception>
+        /// <exception cref="MissingMethodException">Thrown when no method with methodName is found.</exception>
+        /// <exception cref="AmbiguousMatchException">Thrown when more that one method matches the passed method name.</exception>
         /// <returns></returns>
         public static ISetup<T> SetupWithAny<T>(this Mock<T> mock, string methodName)
             where T : class
@@ -53,6 +56,9 @@ namespace Moq.AutoMock
         /// <typeparam name="TResult">The return type of the method</typeparam>
         /// <param name="mock">The mock</param>
         /// <param name="methodName">The name of the expected method invocation.</param>
+        /// <exception cref="ArgumentNullException">When mock or methodName is null.</exception>
+        /// <exception cref="MissingMethodException">Thrown when no method with methodName is found.</exception>
+        /// <exception cref="AmbiguousMatchException">Thrown when more that one method matches the passed method name.</exception>
         /// <returns></returns>
         public static ISetup<T, TResult> SetupWithAny<T, TResult>(this Mock<T> mock, string methodName)
             where T : class

--- a/Moq.AutoMock/MockExtensions.cs
+++ b/Moq.AutoMock/MockExtensions.cs
@@ -84,10 +84,16 @@ namespace Moq.AutoMock
 
         private static LambdaExpression GetExpression<T>(string methodName)
         {
-            //Build up the expression to pass to the Setup method
-            MethodInfo method = typeof(T).GetMethod(methodName)!;
-            if (method is null) throw new MissingMethodException(typeof(T).Name, methodName);
+            var matchingMethods = typeof(T).GetMethods().Where(x => string.Equals(x.Name, methodName, StringComparison.Ordinal)).ToArray();
+            MethodInfo method = matchingMethods.Length switch
+            {
+                0 => throw new MissingMethodException(typeof(T).Name, methodName),
+                1 => matchingMethods[0],
+                _ => throw new AmbiguousMatchException($"Cannot create a Setup on method '{methodName}'. {nameof(SetupWithAny)} does nto support methods with multiple overloads."),
+            };
 
+
+            //Build up the expression to pass to the Setup method
             var itType = typeof(It);
             var isAnyMethod = itType.GetMethod(nameof(It.IsAny));
 

--- a/Moq.AutoMock/Moq.AutoMock.csproj
+++ b/Moq.AutoMock/Moq.AutoMock.csproj
@@ -6,7 +6,7 @@
     <Copyright>Copyright © $([System.DateTime]::UtcNow.ToString("yyyy"))</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
 
-    <VersionPrefix Condition=" '$(VersionPrefix)' == '' ">2.2.0</VersionPrefix>
+    <VersionPrefix Condition=" '$(VersionPrefix)' == '' ">2.3.0</VersionPrefix>
     <VersionPrefix Condition=" '$(Revision)' != '' ">$(VersionPrefix).$(Revision)</VersionPrefix>
 
     <Authors>Tim Kellogg, Adam Hewitt, Kevin Bost</Authors>


### PR DESCRIPTION
Adds an additional extension on Mock<T> to automatically create a setup that where all of the parameters are `It.IsAny<>`. This only works with methods that do not contain overloads.

In addition, it also adds the same functionality onto the AutoMocker class directly.

cc: @cosborn2