### PR TITLE
Fix107

### DIFF
--- a/Moq.AutoMock.Tests/DescribeCombiningTypes.cs
+++ b/Moq.AutoMock.Tests/DescribeCombiningTypes.cs
@@ -17,34 +17,35 @@ namespace Moq.AutoMock.Tests
             Assert.AreSame(mocker.Get<IService3>(), mocker.Get<IService2>());
         }
 
-        //[TestMethod]
-        //public void Convenience_methods_work()
-        //{
-        //    var mocker = new AutoMocker();
-        //    mocker.Combine<IService1, IService2, IService3>();
-        //
-        //    Assert.AreSame(mocker.Get<IService2>(), mocker.Get<IService1>());
-        //    Assert.AreSame(mocker.Get<IService3>(), mocker.Get<IService2>());
-        //}
+        [TestMethod]
+        public void Convenience_methods_work()
+        {
+            var mocker = new AutoMocker();
+            mocker.Combine<IService1, IService2, IService3>();
+
+            Assert.AreSame(mocker.Get<IService2>(), mocker.Get<IService1>());
+            Assert.AreSame(mocker.Get<IService3>(), mocker.Get<IService2>());
+        }
 
         [TestMethod]
+        [Description("Issue 107")]
         public void Combine_method_should_maintain_setups()
         {
-            var mocker2 = new AutoMocker(MockBehavior.Loose);
-            mocker2.GetMock<IDerivedInterface>().Setup(x => x.Foo()).Returns(() => "42");
-            mocker2.Combine(typeof(IDerivedInterface), typeof(IBaseInterface));
+            var mocker = new AutoMocker(MockBehavior.Loose);
+            mocker.GetMock<IDerivedInterface>().Setup(x => x.Foo()).Returns(() => "42");
+            mocker.Combine(typeof(IDerivedInterface), typeof(IBaseInterface));
 
-            Assert.Equals("42", mocker2.Get<IBaseInterface>().Foo());
-            Assert.Equals("42", mocker2.Get<IDerivedInterface>().Foo());
+            Assert.AreEqual("42", mocker.Get<IBaseInterface>().Foo());
+            Assert.AreEqual("42", mocker.Get<IDerivedInterface>().Foo());
         }
+    }
 
-        interface IBaseInterface
-        {
-            string Foo();
-        }
-        interface IDerivedInterface : IBaseInterface
-        {
-            string Bar();
-        }
+    public interface IBaseInterface
+    {
+        string Foo();
+    }
+
+    public interface IDerivedInterface : IBaseInterface
+    {
     }
 }

--- a/Moq.AutoMock.Tests/DescribeCombiningTypes.cs
+++ b/Moq.AutoMock.Tests/DescribeCombiningTypes.cs
@@ -17,14 +17,34 @@ namespace Moq.AutoMock.Tests
             Assert.AreSame(mocker.Get<IService3>(), mocker.Get<IService2>());
         }
 
-        [TestMethod]
-        public void Convenience_methods_work()
-        {
-            var mocker = new AutoMocker();
-            mocker.Combine<IService1, IService2, IService3>();
+        //[TestMethod]
+        //public void Convenience_methods_work()
+        //{
+        //    var mocker = new AutoMocker();
+        //    mocker.Combine<IService1, IService2, IService3>();
+        //
+        //    Assert.AreSame(mocker.Get<IService2>(), mocker.Get<IService1>());
+        //    Assert.AreSame(mocker.Get<IService3>(), mocker.Get<IService2>());
+        //}
 
-            Assert.AreSame(mocker.Get<IService2>(), mocker.Get<IService1>());
-            Assert.AreSame(mocker.Get<IService3>(), mocker.Get<IService2>());
+        [TestMethod]
+        public void Combine_method_should_maintain_setups()
+        {
+            var mocker2 = new AutoMocker(MockBehavior.Loose);
+            mocker2.GetMock<IDerivedInterface>().Setup(x => x.Foo()).Returns(() => "42");
+            mocker2.Combine(typeof(IDerivedInterface), typeof(IBaseInterface));
+
+            Assert.Equals("42", mocker2.Get<IBaseInterface>().Foo());
+            Assert.Equals("42", mocker2.Get<IDerivedInterface>().Foo());
+        }
+
+        interface IBaseInterface
+        {
+            string Foo();
+        }
+        interface IDerivedInterface : IBaseInterface
+        {
+            string Bar();
         }
     }
 }

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -96,7 +96,7 @@ namespace Moq.AutoMock
             if (serviceType.IsArray)
             {
                 Type elmType = serviceType.GetElementType() ?? throw new InvalidOperationException($"Could not determine element type for '{serviceType}'");
-                MockArrayInstance instance = new MockArrayInstance(elmType);
+                MockArrayInstance instance = new(elmType);
                 if (_typeMap.TryGetValue(elmType, out var element))
                     instance.Add(element);
                 return instance;
@@ -526,12 +526,9 @@ namespace Moq.AutoMock
         {
             if (type is null) throw new ArgumentNullException(nameof(type));
 
-            if (Resolve(type, new ObjectGraphContext(false)) is not MockInstance mockObject)
-                throw new ArgumentException($"{type} did not resolve to a Mock", nameof(type));
-
-            _ = forwardTo.Aggregate(mockObject.Mock, As);
-            foreach (var serviceType in forwardTo.Concat(new[] { type }))
-                _typeMap[serviceType] = mockObject;
+            Mock mock = forwardTo.Aggregate(GetOrMakeMockFor(type), As);
+            foreach (var serviceType in new[] { type }.Concat(forwardTo))
+                _typeMap[serviceType] = new MockInstance(mock);
 
             static Mock As(Mock mock, Type forInterface)
             {


### PR DESCRIPTION
Fixes #107 

The Combine method was not properly retrieving existing instances out of the cached map; causing it to appear like it was wiping out the previous setup.