### PR TITLE
Smoothing CreateSelfMock

### DIFF
--- a/Moq.AutoMock.Tests/DescribeCreatingSelfMocks.cs
+++ b/Moq.AutoMock.Tests/DescribeCreatingSelfMocks.cs
@@ -9,7 +9,7 @@ public class DescribeCreatingSelfMocks
     [TestMethod]
     public void Self_mocks_are_useful_for_testing_most_of_class()
     {
-        var mocker = new AutoMocker();
+        AutoMocker mocker = new();
         var selfMock = mocker.CreateSelfMock<InsecureAboutSelf>();
         selfMock.TellJoke();
         Assert.IsFalse(selfMock.SelfDepricated);
@@ -18,7 +18,7 @@ public class DescribeCreatingSelfMocks
     [TestMethod]
     public void It_can_self_mock_objects_with_constructor_arguments()
     {
-        var mocker = new AutoMocker();
+        AutoMocker mocker = new();
         var selfMock = mocker.CreateSelfMock<WithService>();
         Assert.IsNotNull(selfMock.Service);
         Assert.IsNotNull(Mock.Get(selfMock.Service));
@@ -28,9 +28,58 @@ public class DescribeCreatingSelfMocks
     [Description("Issue 130")]
     public void It_reuses_dependencies_when_creating_self_mock()
     {
-        var mocker = new AutoMocker();
+        AutoMocker mocker = new();
         var service = mocker.CreateSelfMock<AbstractService>();
         Assert.IsTrue(ReferenceEquals(service.Dependency, mocker.GetMock<IDependency>().Object));
+    }
+
+    [TestMethod]
+    [Description("Issue 134")]
+    public void It_can_specify_self_mock_with_different_defaults()
+    {
+        AutoMocker mocker = new(MockBehavior.Loose);
+        var fooService = mocker.CreateSelfMock<FooService>(mockBehavior: MockBehavior.Strict, defaultValue: DefaultValue.Mock, callBase: true);
+
+        var mock = Mock.Get(fooService);
+        Assert.AreEqual(MockBehavior.Strict, mock.Behavior);
+        Assert.AreEqual(DefaultValue.Mock, mock.DefaultValue);
+        Assert.AreEqual(true, mock.CallBase);
+    }
+
+    [TestMethod]
+    [Description("Issue 134")]
+    public void It_can_perform_setup_on_interface_of_self_mock_that_is_registered()
+    {
+        AutoMocker mocker = new();
+        var service = mocker.WithSelfMock<IFooService, FooService>();
+        mocker.Setup<IFooService, int>(s => s.Foo()).Returns(24);
+    }
+
+    [TestMethod]
+    [Description("Issue 134")]
+    public void It_can_perform_setup_class_of_self_mock_that_is_registered()
+    {
+        AutoMocker mocker = new();
+        var service = mocker.WithSelfMock<FooService>();
+        mocker.Setup<FooService, int>(s => s.Foo()).Returns(24);
+    }
+
+    [TestMethod]
+    [Description("Issue 134")]
+    public void It_can_perform_setup_on_interface_of_self_mock_that_is_registered_without_generics()
+    {
+        AutoMocker mocker = new();
+        var service = mocker.WithSelfMock(typeof(IFooService), typeof(FooService));
+        mocker.Setup<IFooService, int>(s => s.Foo()).Returns(24);
+    }
+
+    [TestMethod]
+    [Description("Issue 134")]
+    public void It_can_perform_setup_class_of_self_mock_that_is_registered_without_generics()
+    {
+        AutoMocker mocker = new();
+        var service = mocker.WithSelfMock(typeof(FooService));
+        mocker.Setup<FooService, int>(s => s.Foo()).Returns(24);
     }
 
     public abstract class AbstractService
@@ -40,4 +89,13 @@ public class DescribeCreatingSelfMocks
     }
 
     public interface IDependency { }
+
+    public interface IFooService 
+    { 
+        int Foo();
+    }
+    public class FooService : IFooService
+    {
+        public virtual int Foo() => 42;
+    }
 }

--- a/Moq.AutoMock/IInstance.cs
+++ b/Moq.AutoMock/IInstance.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Moq.AutoMock;
+﻿namespace Moq.AutoMock;
 
 internal interface IInstance
 {

--- a/Moq.AutoMock/MockExtensions.cs
+++ b/Moq.AutoMock/MockExtensions.cs
@@ -109,4 +109,16 @@ public static class MockExtensions
         var methodCallExpression = Expression.Call(xExpression, method, parameterExpressions);
         return Expression.Lambda(methodCallExpression, false, new[] { xExpression });
     }
+
+    private static Lazy<MethodInfo?> AsMethod { get; } = new(() => typeof(Mock).GetMethod(nameof(Mock.As)));
+
+    internal static Mock As(this Mock mock, Type interfaceType)
+    {
+        if (AsMethod.Value is { } method)
+        {
+            return (Mock)method.MakeGenericMethod(interfaceType)
+                .Invoke(mock, Array.Empty<object>());
+        }
+        throw new InvalidOperationException($"Could not find {typeof(Mock).FullName}.{nameof(Mock.As)} method");
+    }
 }


### PR DESCRIPTION
This is a proposed fix for #134 (more overloads would need to be created if this is deemed an acceptable fix).

First this adds an additional overload for CreateSelfMock to allow for setting CallBase and MockBehavior.

Second this adds an additional "WithSelfMock" method that creates a self mock and also registers it so that it can be referenced with subsequent `Setup` calls. This is inline with the existing "With" methods that call `CreateInstance` and register the created instance.