### PR TITLE
Fixing issue with generated methods having invalid characters

### DIFF
--- a/GeneratorTests/Moq.AutoMocker.Generator.Example/Controller.cs
+++ b/GeneratorTests/Moq.AutoMocker.Generator.Example/Controller.cs
@@ -19,5 +19,10 @@ public class Controller
         Name = name ?? throw new ArgumentNullException(nameof(name));
     }
 
+    public Controller(ILogger<Controller> logger)
+    {
+        _ = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
     public string Name { get; } = "";
 }

--- a/GeneratorTests/Moq.AutoMocker.Generator.Example/ILogger.cs
+++ b/GeneratorTests/Moq.AutoMocker.Generator.Example/ILogger.cs
@@ -1,0 +1,6 @@
+﻿namespace Moq.AutoMock.Generator.Example;
+
+public interface ILogger<T>
+{
+
+}

--- a/Moq.AutoMocker.TestGenerator.Tests/CSharpSourceGeneratorVerifier.cs
+++ b/Moq.AutoMocker.TestGenerator.Tests/CSharpSourceGeneratorVerifier.cs
@@ -2,7 +2,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
 
 namespace Moq.AutoMocker.TestGenerator.Tests;

--- a/Moq.AutoMocker.TestGenerator/TargetTestingFramework.cs
+++ b/Moq.AutoMocker.TestGenerator/TargetTestingFramework.cs
@@ -1,0 +1,9 @@
+﻿namespace Moq.AutoMocker.TestGenerator;
+
+public enum TargetTestingFramework
+{
+    Unknown,
+    MSTest,
+    Xunit,
+    NUnit
+}

--- a/Moq.AutoMocker.TestGenerator/TestNameBuilder.cs
+++ b/Moq.AutoMocker.TestGenerator/TestNameBuilder.cs
@@ -1,0 +1,43 @@
+﻿using System.Text;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Moq.AutoMocker.TestGenerator;
+
+internal static class TestNameBuilder
+{
+    public static IEnumerable<string> CreateTestName(GeneratorTargetClass testClass, NullConstructorParameterTest test)
+    {
+        int testNameIndex = 0;
+        for (string testName = $"{testClass.Sut!.Name}Constructor_WithNull{test.NullTypeName}_ThrowsArgumentNullException";
+            ;
+            testName = $"{testClass.Sut!.Name}Constructor_WithNull{test.NullTypeName}{++testNameIndex}_ThrowsArgumentNullException")
+        {
+            if (!SyntaxFacts.IsValidIdentifier(testName))
+            {
+                StringBuilder sb = new(testName.Length);
+                for (int i = 0; i < testName.Length; i++)
+                {
+                    if (sb.Length == 0)
+                    {
+                        if (SyntaxFacts.IsIdentifierStartCharacter(testName[i]))
+                        {
+                            sb.Append(testName[i]);
+                        }
+                    }
+                    else
+                    {
+                        if (SyntaxFacts.IsIdentifierPartCharacter(testName[i]))
+                        {
+                            sb.Append(testName[i]);
+                        }
+                    }
+                }
+                yield return sb.ToString();
+            }
+            else
+            {
+                yield return testName;
+            }
+        }
+    }
+}


### PR DESCRIPTION
When an identifier is invalid, the generator will now strip out all invalid characters.

Fixes #142 