### PR TITLE
Adding support for DefaultValueProvider

### DIFF
--- a/Moq.AutoMock.Tests/ConstructorSelectorTests.cs
+++ b/Moq.AutoMock.Tests/ConstructorSelectorTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Reflection;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq.AutoMock.Tests.Util;
+﻿using System.Reflection;
 
 namespace Moq.AutoMock.Tests;
 

--- a/Moq.AutoMock.Tests/DescribeCreatingSelfMocks.cs
+++ b/Moq.AutoMock.Tests/DescribeCreatingSelfMocks.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq.AutoMock.Tests.Util;
-
-namespace Moq.AutoMock.Tests;
+﻿namespace Moq.AutoMock.Tests;
 
 [TestClass]
 public class DescribeCreatingSelfMocks
@@ -82,6 +79,30 @@ public class DescribeCreatingSelfMocks
         mocker.Setup<FooService, int>(s => s.Foo()).Returns(24);
     }
 
+    [TestMethod]
+    [Description("Issue 144")]
+    public void It_can_register_a_custom_default_value_provider_for_a_self_mock()
+    {
+        AutoMocker mocker = new();
+        CustomDefaultValueProvider provider = new();
+
+        var mock = mocker.CreateSelfMock<InsecureAboutSelf>(defaultValue: DefaultValue.Custom, defaultValueProvider: provider);
+
+        Assert.AreEqual(provider, Mock.Get(mock).DefaultValueProvider);
+    }
+
+    [TestMethod]
+    [Description("Issue 144")]
+    public void It_uses_default_value_provider_for_a_self_mock()
+    {
+        CustomDefaultValueProvider provider = new();
+        AutoMocker mocker = new(MockBehavior.Default, DefaultValue.Custom, provider, false);
+
+        var mock = mocker.CreateSelfMock<InsecureAboutSelf>();
+
+        Assert.AreEqual(provider, Mock.Get(mock).DefaultValueProvider);
+    }
+
     public abstract class AbstractService
     {
         public IDependency Dependency { get; }
@@ -90,8 +111,8 @@ public class DescribeCreatingSelfMocks
 
     public interface IDependency { }
 
-    public interface IFooService 
-    { 
+    public interface IFooService
+    {
         int Foo();
     }
     public class FooService : IFooService

--- a/Moq.AutoMock.Tests/DescribeDefaultValues.cs
+++ b/Moq.AutoMock.Tests/DescribeDefaultValues.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq.AutoMock.Tests.Util;
+
+namespace Moq.AutoMock.Tests;
+
+[TestClass]
+public class DescribeDefaultValues
+{
+    [TestMethod]
+    [DataRow(DefaultValue.Mock)]
+    [DataRow(DefaultValue.Empty)]
+    [Description("Issue 144")]
+    public void It_creates_mocks_with_default_value_set(DefaultValue defaultValue)
+    {
+        AutoMocker mocker = new(MockBehavior.Default, defaultValue);
+
+        Mock<IService1> mock = mocker.GetMock<IService1>();
+
+        Assert.AreEqual(defaultValue, mock.DefaultValue);
+    }
+
+    [TestMethod]
+    [Description("Issue 144")]
+    public void It_creates_mocks_with_custom_default_value_resolver()
+    {
+        CustomDefaultValueProvider defaultValueProvider = new(); 
+        AutoMocker mocker = new(MockBehavior.Default, DefaultValue.Custom, defaultValueProvider, false);
+
+        Mock<IService1> mock = mocker.GetMock<IService1>();
+
+        Assert.AreEqual(DefaultValue.Custom, mock.DefaultValue);
+        Assert.AreEqual(defaultValueProvider, mock.DefaultValueProvider);
+    }
+
+    private class CustomDefaultValueProvider : DefaultValueProvider
+    {
+        protected override object GetDefaultValue(Type type, Mock mock)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Moq.AutoMock.Tests/DescribeWith.cs
+++ b/Moq.AutoMock.Tests/DescribeWith.cs
@@ -46,3 +46,4 @@ public class DescribeWith
         Assert.IsInstanceOfType(mocker.Get<Service2>(), typeof(Service2));
     }
 }
+

--- a/Moq.AutoMock.Tests/DescribeWithSelfMock.cs
+++ b/Moq.AutoMock.Tests/DescribeWithSelfMock.cs
@@ -1,0 +1,102 @@
+﻿namespace Moq.AutoMock.Tests;
+
+[TestClass]
+public class DescribeWithSelfMock
+{
+    [TestMethod]
+    [Description("Issue 144")]
+    public void It_can_register_a_custom_default_value_provider_for_a_self_mock_with_interface()
+    {
+        AutoMocker mocker = new();
+        CustomDefaultValueProvider provider = new();
+
+        var mock = mocker.WithSelfMock<IService2, Service2>(defaultValue: DefaultValue.Custom, defaultValueProvider: provider);
+
+        Assert.AreEqual(provider, Mock.Get(mock).DefaultValueProvider);
+    }
+
+    [TestMethod]
+    [Description("Issue 144")]
+    public void It_uses_default_value_provider_for_a_self_mock_with_interface()
+    {
+        CustomDefaultValueProvider provider = new();
+        AutoMocker mocker = new(MockBehavior.Default, DefaultValue.Custom, provider, false);
+
+        var mock = mocker.WithSelfMock<IService2, Service2>();
+
+        Assert.AreEqual(provider, Mock.Get(mock).DefaultValueProvider);
+    }
+
+    [TestMethod]
+    [Description("Issue 144")]
+    public void It_can_register_a_custom_default_value_provider_for_a_self_mock_with_class()
+    {
+        AutoMocker mocker = new();
+        CustomDefaultValueProvider provider = new();
+
+        var mock = mocker.WithSelfMock<Service2>(defaultValue: DefaultValue.Custom, defaultValueProvider: provider);
+
+        Assert.AreEqual(provider, Mock.Get(mock).DefaultValueProvider);
+    }
+
+    [TestMethod]
+    [Description("Issue 144")]
+    public void It_uses_default_value_provider_for_a_self_mock_with_class()
+    {
+        CustomDefaultValueProvider provider = new();
+        AutoMocker mocker = new(MockBehavior.Default, DefaultValue.Custom, provider, false);
+
+        var mock = mocker.WithSelfMock<Service2>();
+
+        Assert.AreEqual(provider, Mock.Get(mock).DefaultValueProvider);
+    }
+
+    [TestMethod]
+    [Description("Issue 144")]
+    public void It_can_register_a_custom_default_value_provider_for_a_self_mock_with_interface_type()
+    {
+        AutoMocker mocker = new();
+        CustomDefaultValueProvider provider = new();
+
+        var mock = (Service2)mocker.WithSelfMock(typeof(IService2), typeof(Service2), defaultValue: DefaultValue.Custom, defaultValueProvider: provider);
+
+        Assert.AreEqual(provider, Mock.Get(mock).DefaultValueProvider);
+    }
+
+    [TestMethod]
+    [Description("Issue 144")]
+    public void It_uses_default_value_provider_for_a_self_mock_with_interface_type()
+    {
+        CustomDefaultValueProvider provider = new();
+        AutoMocker mocker = new(MockBehavior.Default, DefaultValue.Custom, provider, false);
+
+        var mock = (Service2)mocker.WithSelfMock(typeof(IService2), typeof(Service2));
+
+        Assert.AreEqual(provider, Mock.Get(mock).DefaultValueProvider);
+    }
+
+    [TestMethod]
+    [Description("Issue 144")]
+    public void It_can_register_a_custom_default_value_provider_for_a_self_mock_with_class_type()
+    {
+        AutoMocker mocker = new();
+        CustomDefaultValueProvider provider = new();
+
+        var mock = (Service2)mocker.WithSelfMock(typeof(Service2), defaultValue: DefaultValue.Custom, defaultValueProvider: provider);
+
+        Assert.AreEqual(provider, Mock.Get(mock).DefaultValueProvider);
+    }
+
+    [TestMethod]
+    [Description("Issue 144")]
+    public void It_uses_default_value_provider_for_a_self_mock_with_class_type()
+    {
+        CustomDefaultValueProvider provider = new();
+        AutoMocker mocker = new(MockBehavior.Default, DefaultValue.Custom, provider, false);
+
+        var mock = (Service2)mocker.WithSelfMock(typeof(Service2));
+
+        Assert.AreEqual(provider, Mock.Get(mock).DefaultValueProvider);
+    }
+}
+

--- a/Moq.AutoMock.Tests/Moq.AutoMock.Tests.csproj
+++ b/Moq.AutoMock.Tests/Moq.AutoMock.Tests.csproj
@@ -22,6 +22,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Using Include="Moq.AutoMock.Tests.Util" />
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <PackageReference Include="Moq" version="4.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.9" />

--- a/Moq.AutoMock.Tests/Util/CustomDefaultValueProvider.cs
+++ b/Moq.AutoMock.Tests/Util/CustomDefaultValueProvider.cs
@@ -1,0 +1,14 @@
+﻿namespace Moq.AutoMock.Tests.Util;
+internal class CustomDefaultValueProvider : DefaultValueProvider
+{
+    public Dictionary<Type, object?> DefaultValues { get; } = new();
+
+    protected override object? GetDefaultValue(Type type, Mock mock)
+    {
+        if (DefaultValues.TryGetValue(type, out object? value))
+        {
+            return value;
+        }
+        return null;
+    }
+}

--- a/Moq.AutoMock.lutconfig
+++ b/Moq.AutoMock.lutconfig
@@ -1,0 +1,7 @@
+<LUTConfig Version="1.0">
+  <Repository />
+  <ParallelBuilds>true</ParallelBuilds>
+  <ParallelTestRuns>true</ParallelTestRuns>
+  <EnablePdbs>false</EnablePdbs>
+  <TestCaseTimeout>180000</TestCaseTimeout>
+</LUTConfig>

--- a/Moq.AutoMock/Resolvers/MockResolver.cs
+++ b/Moq.AutoMock/Resolvers/MockResolver.cs
@@ -7,6 +7,7 @@ public class MockResolver : IMockResolver
 {
     private readonly MockBehavior _mockBehavior;
     private readonly DefaultValue _defaultValue;
+    private readonly DefaultValueProvider? _defaultValueProvider;
     private readonly bool _callBase;
 
     /// <summary>
@@ -18,9 +19,27 @@ public class MockResolver : IMockResolver
     /// <param name="callBase">Whether the base member virtual implementation will be called 
     /// for created mocks if no setup is matched.</param>
     public MockResolver(MockBehavior mockBehavior, DefaultValue defaultValue, bool callBase)
+        : this(mockBehavior, defaultValue, null, callBase)
+    { }
+
+    /// <summary>
+    /// Initializes an instance of <c>MockResolver</c>.
+    /// </summary>
+    /// <param name="mockBehavior">Behavior of created mock.</param>
+    /// <param name="defaultValue">Specifies the behavior to use when returning default values for 
+    /// unexpected invocations on loose mocks created by this instance.</param>
+    /// <param name="defaultValueProvider">The instance that will be used to produce default return values for unexpected invocations.</param>
+    /// <param name="callBase">Whether the base member virtual implementation will be called 
+    /// for created mocks if no setup is matched.</param>
+    public MockResolver(
+        MockBehavior mockBehavior, 
+        DefaultValue defaultValue, 
+        DefaultValueProvider? defaultValueProvider, 
+        bool callBase)
     {
         _mockBehavior = mockBehavior;
         _defaultValue = defaultValue;
+        _defaultValueProvider = defaultValueProvider;
         _callBase = callBase;
     }
 
@@ -36,6 +55,7 @@ public class MockResolver : IMockResolver
             context.RequestType,
             _mockBehavior,
             _defaultValue,
+            _defaultValueProvider,
             _callBase, 
             context.ObjectGraphContext) is { } mock)
         {


### PR DESCRIPTION
This exposes the DefaultValueProvider property from Mock<T> through AutoMocker.

fixes #144 