### PR TITLE
Adding cancellation token support.

### DIFF
--- a/GeneratorTests/Moq.AutoMocker.Generator.Example/Controller.cs
+++ b/GeneratorTests/Moq.AutoMocker.Generator.Example/Controller.cs
@@ -24,5 +24,11 @@ public class Controller
         _ = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
+    public Controller(ILogger<Controller> logger, CancellationToken token)
+    {
+        _ = logger ?? throw new ArgumentNullException(nameof(logger));
+        _ = token;
+    }
+
     public string Name { get; } = "";
 }

--- a/Moq.AutoMock.Tests/ResolvesCancellationToken.cs
+++ b/Moq.AutoMock.Tests/ResolvesCancellationToken.cs
@@ -1,0 +1,39 @@
+﻿namespace Moq.AutoMock.Tests;
+
+[TestClass]
+public class ResolvesCancellationToken
+{
+    [TestMethod]
+    public void Resolves_cancellation_token_none_when_nothing_has_been_registered()
+    {
+        AutoMocker mocker = new();
+
+        CancellationToken token = mocker.Get<CancellationToken>();
+
+        Assert.AreEqual(CancellationToken.None, token);
+    }
+
+    [TestMethod]
+    public void Resolves_cancellation_token_with_cached_instance()
+    {
+        using CancellationTokenSource cts = new();
+        AutoMocker mocker = new();
+        mocker.Use(cts.Token);
+
+        CancellationToken token = mocker.Get<CancellationToken>();
+
+        Assert.AreEqual(cts.Token, token);
+    }
+
+    [TestMethod]
+    public void Resolves_cancellation_token_from_cached_cancellation_token_source()
+    {
+        using CancellationTokenSource cts = new();
+        AutoMocker mocker = new();
+        mocker.Use(cts);
+
+        CancellationToken token = mocker.Get<CancellationToken>();
+
+        Assert.AreEqual(cts.Token, token);
+    }
+}

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -76,6 +76,7 @@ public partial class AutoMocker : IServiceProvider
             new EnumerableResolver(),
             new LazyResolver(),
             new FuncResolver(),
+            new CancellationTokenResolver(),
             new MockResolver(mockBehavior, defaultValue, defaultValueProvider, callBase),
         };
     }
@@ -536,12 +537,12 @@ public partial class AutoMocker : IServiceProvider
     /// </summary>
     /// <typeparam name="TService">The class or interface to search on</typeparam>
     /// <returns>The object that implements TService</returns>
-    public TService Get<TService>() where TService : class?
+    public TService Get<TService>()
     {
         if (Get(typeof(TService)) is TService service)
             return service;
 
-        return null!;
+        return default!;
     }
 
     /// <summary>
@@ -551,12 +552,12 @@ public partial class AutoMocker : IServiceProvider
     /// <typeparam name="TService">The class or interface to search on</typeparam>
     /// <param name="enablePrivate">When true, non-public constructors will also be used to create mocks.</param>
     /// <returns>The object that implements TService</returns>
-    public TService Get<TService>(bool enablePrivate) where TService : class?
+    public TService Get<TService>(bool enablePrivate)
     {
         if (Get(typeof(TService), enablePrivate) is TService service)
             return service;
 
-        return null!;
+        return default!;
     }
 
     /// <summary>

--- a/Moq.AutoMock/Resolvers/CancellationTokenResolver.cs
+++ b/Moq.AutoMock/Resolvers/CancellationTokenResolver.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Moq.AutoMock.Resolvers;
+/// <summary>
+/// A resolve that can provide a <see cref="CancellationToken"/>
+/// </summary>
+public class CancellationTokenResolver : IMockResolver
+{
+    /// <inheritdoc />
+    public void Resolve(MockResolutionContext context)
+    {
+        if (context.RequestType == typeof(CancellationToken))
+        {
+            if (context.AutoMocker.ResolvedObjects?.TryGetValue(typeof(CancellationTokenSource), out object? ctsObject) == true &&
+                ctsObject is CancellationTokenSource cts)
+            {
+                context.Value = cts.Token;
+            }
+            else
+            {
+                context.Value = CancellationToken.None;
+            }
+        }
+    }
+}

--- a/Moq.AutoMocker.TestGenerator.Tests/UnitTests.cs
+++ b/Moq.AutoMocker.TestGenerator.Tests/UnitTests.cs
@@ -140,6 +140,50 @@ public interface ILogger<Controller> { }
         }.RunAsync();
     }
 
+    [TestMethod]
+    public async Task Generation_WithValueTypeParameter_DoesNotGenerateTest()
+    {
+        var code = @"
+using Moq.AutoMock;
+using System.Threading;
+
+namespace TestNamespace;
+
+[ConstructorTests(typeof(Controller))]
+public partial class ControllerTests
+{
+    
+}
+
+public class Controller
+{
+    public Controller(CancellationToken token) { }
+}
+";
+        string expected = @"namespace TestNamespace
+{
+    partial class ControllerTests
+    {
+        partial void AutoMockerTestSetup(Moq.AutoMock.AutoMocker mocker, string testName);
+
+    }
+}
+";
+
+        await new VerifyCS.Test
+        {
+            TestCode = code,
+            TestState =
+            {
+                GeneratedSources =
+                {
+                    GetSourceFile(expected, "ControllerTests.g.cs")
+                }
+            }
+
+        }.RunAsync();
+    }
+
     private static (string FileName, SourceText SourceText) GetSourceFile(string content, string fileName)
     {
         return (Path.Combine("Moq.AutoMocker.TestGenerator", "Moq.AutoMocker.TestGenerator.UnitTestSourceGenerator", fileName), SourceText.From(content, Encoding.UTF8));

--- a/Moq.AutoMocker.TestGenerator/SyntaxReceiver.cs
+++ b/Moq.AutoMocker.TestGenerator/SyntaxReceiver.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -66,6 +66,7 @@ public class SyntaxReceiver : ISyntaxContextReceiver
                 int nullIndex = 0;
                 foreach (IParameterSymbol parameter in ctor.Parameters)
                 {
+                    if (parameter.Type.IsValueType) continue;
                     sut.NullConstructorParameterTests.Add(new NullConstructorParameterTest()
                     {
                         Parameters = parameters,


### PR DESCRIPTION
There are a few changes here:
1. This adds a new resolver to automatically handle CancellationToken. Defaults to CancellationToken.None, but will use injected tokens or CancellationTokenSources to resolve if they are present.
2. This drops the class generic constraint from the AutoMocker.Get<T>  methods. This was initially in place because there is a class constraint on Moq.Mock<T>, however with resolvers it is perfectly valid to want to retrieve value types (such as CancellationToken).
3. The source generator was updated to not generate argument null tests for value types.