### PR TITLE
Drop net461

### DIFF
--- a/Moq.AutoMock/Moq.AutoMock.csproj
+++ b/Moq.AutoMock/Moq.AutoMock.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <Copyright>Copyright © $([System.DateTime]::UtcNow.ToString("yyyy"))</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/Moq.AutoMock/Moq.AutoMock.csproj
+++ b/Moq.AutoMock/Moq.AutoMock.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <Copyright>Copyright © $([System.DateTime]::UtcNow.ToString("yyyy"))</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>


### PR DESCRIPTION
Net461 reached EOL back in April of last year. Once we go to compiling with the latest .NET 7 SDK it will no longer be supported. Bumping the minimum up to net462. 

https://learn.microsoft.com/lifecycle/products/microsoft-net-framework