### PR TITLE
VerifyAll throws when there are no setups

### DIFF
--- a/Moq.AutoMock.Tests/DescribeVerifyAll.cs
+++ b/Moq.AutoMock.Tests/DescribeVerifyAll.cs
@@ -25,7 +25,7 @@ public class DescribeVerifyAll
         var mocker = new AutoMocker();
         mocker.Use<IService2>(new Service2());
         mocker.CreateInstance<WithService>();
-        mocker.VerifyAll();
+        mocker.VerifyAll(ignoreMissingSetups:true);
     }
 
     [TestMethod]
@@ -35,5 +35,22 @@ public class DescribeVerifyAll
         mocker.Resolvers.Remove(mocker.Resolvers.OfType<CacheResolver>().Single());
 
         Assert.ThrowsException<InvalidOperationException>(() => mocker.VerifyAll());
+    }
+
+    [TestMethod]
+    public void It_throws_if_there_are_no_mocks_with_setups()
+    {
+        AutoMocker mocker = new();
+
+        InvalidOperationException ex = Assert.ThrowsException<InvalidOperationException>(() => mocker.VerifyAll());
+        Assert.AreEqual("VerifyAll was called, but there were no setups on any tracked mock instances to verify", ex.Message);
+    }
+
+    [TestMethod]
+    public void It_does_not_throw_on_missing_setups_when_flag_is_set()
+    {
+        AutoMocker mocker = new();
+
+        mocker.VerifyAll(ignoreMissingSetups: true);
     }
 }

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -833,14 +833,22 @@ public partial class AutoMocker : IServiceProvider
     /// <summary>
     /// This is a shortcut for calling `mock.VerifyAll()` on every mock that we have.
     /// </summary>
-    public void VerifyAll()
+    public void VerifyAll(bool ignoreMissingSetups = false)
     {
         if (!(TypeMap is { } typeMap)) throw new InvalidOperationException($"{nameof(CacheResolver)} was not found. Cannot verify expectations without resolver.");
 
+        bool foundSetups = false;
         foreach (var pair in typeMap)
         {
             if (pair.Value is MockInstance instance)
+            {
+                foundSetups |= instance.Mock.Setups.Any();
                 instance.Mock.VerifyAll();
+            }
+        }
+        if (!ignoreMissingSetups && !foundSetups)
+        {
+            throw new InvalidOperationException($"{nameof(VerifyAll)} was called, but there were no setups on any tracked mock instances to verify");
         }
     }
 


### PR DESCRIPTION
This is another common case where people write VerifyAll at the end of their test method. But if the test does not have any setups to verify this call effectively does nothing and gives the illusion that the test is verifying something when it is not.