### PR TITLE
Allow With* method to return the instance they create

### DIFF
--- a/Moq.AutoMock.Tests/DescribeWith.cs
+++ b/Moq.AutoMock.Tests/DescribeWith.cs
@@ -7,13 +7,15 @@ namespace Moq.AutoMock.Tests;
 public class DescribeWith
 {
     [TestMethod]
-    public void You_can_register_a_concrete_instance_by_its_iterface()
+    public void You_can_register_a_concrete_instance_by_its_interface()
     {
         AutoMocker mocker = new();
 
-        mocker.With<IService2, Service2>();
+        Service2 instance = mocker.With<IService2, Service2>();
 
-        Assert.IsInstanceOfType(mocker.Get<IService2>(), typeof(Service2));
+        IService2 retrieved = mocker.Get<IService2>();
+        Assert.IsInstanceOfType(retrieved, typeof(Service2));
+        Assert.AreSame(instance, retrieved);
     }
 
     [TestMethod]
@@ -21,19 +23,23 @@ public class DescribeWith
     {
         AutoMocker mocker = new();
 
-        mocker.With<Service2>();
+        Service2 instance = mocker.With<Service2>();
 
-        Assert.IsInstanceOfType(mocker.Get<Service2>(), typeof(Service2));
+        Service2 retrieved = mocker.Get<Service2>();
+        Assert.AreSame(instance, retrieved);
     }
 
     [TestMethod]
-    public void You_can_register_a_concrete_instance_by_its_iterface_non_generic()
+    public void You_can_register_a_concrete_instance_by_its_interface_non_generic()
     {
         AutoMocker mocker = new();
 
-        mocker.With(typeof(IService2), typeof(Service2));
+        object instance = mocker.With(typeof(IService2), typeof(Service2));
 
-        Assert.IsInstanceOfType(mocker.Get<IService2>(), typeof(Service2));
+        IService2 retrieved = mocker.Get<IService2>();
+        Assert.IsInstanceOfType(retrieved, typeof(Service2));
+        Assert.IsInstanceOfType(instance, typeof(Service2));
+        Assert.AreSame(instance, retrieved);
     }
 
     [TestMethod]
@@ -41,9 +47,12 @@ public class DescribeWith
     {
         AutoMocker mocker = new();
 
-        mocker.With(typeof(Service2));
+        object instance = mocker.With(typeof(Service2));
 
-        Assert.IsInstanceOfType(mocker.Get<Service2>(), typeof(Service2));
+        Service2 retrieved = mocker.Get<Service2>();
+        Assert.IsInstanceOfType(retrieved, typeof(Service2));
+        Assert.IsInstanceOfType(instance, typeof(Service2));
+        Assert.AreSame(instance, retrieved);
     }
 }
 

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -512,32 +512,52 @@ public partial class AutoMocker : IServiceProvider
     /// </summary>
     /// <typeparam name="TService">The service type</typeparam>
     /// <typeparam name="TImplementation">The service implementation type</typeparam>
-    public void With<TService, TImplementation>()
+    /// <returns>The created instance</returns>
+    public TImplementation With<TService, TImplementation>()
         where TImplementation : class, TService
-        => Use<TService>(CreateInstance<TImplementation>());
+    {
+        TImplementation instance = CreateInstance<TImplementation>();
+        Use<TService>(instance);
+        return instance;
+    }
 
     /// <summary>
     /// Creates an instance of <typeparamref name="TImplementation"/> and registers it as for service type <typeparamref name="TImplementation"/>.
     /// This is a convenience method for Use&lt;<typeparamref name="TImplementation"/>&gt;(CreateInstance&lt;<typeparamref name="TImplementation"/>&gt;())
     /// </summary>
     /// <typeparam name="TImplementation">The service implementation type</typeparam>
-    public void With<TImplementation>()
+    /// <returns>The created instance</returns>
+    public TImplementation With<TImplementation>()
         where TImplementation : class
-        => Use(CreateInstance<TImplementation>());
+    {
+        TImplementation instance = CreateInstance<TImplementation>();
+        Use(instance);
+        return instance;
+    }
 
     /// <summary>
     /// Creates an instance of <paramref name="implementationType"/> and registers it for service type <paramref name="serviceType"/>.
     /// This is a convenience method for Use(<paramref name="serviceType"/>, CreateInstance(<paramref name="implementationType"/>))
     /// </summary>
-    public void With(Type serviceType, Type implementationType)
-        => Use(serviceType, CreateInstance(implementationType));
+    /// <returns>The created instance</returns>
+    public object With(Type serviceType, Type implementationType)
+    {
+        object instance = CreateInstance(implementationType);
+        Use(serviceType, instance);
+        return instance;
+    }
 
     /// <summary>
     /// Creates an instance of <paramref name="implementationType"/> and registers it for service type <paramref name="implementationType"/>.
     /// This is a convenience method for Use(<paramref name="implementationType"/>, CreateInstance(<paramref name="implementationType"/>))
     /// </summary>
-    public void With(Type implementationType)
-        => Use(implementationType, CreateInstance(implementationType));
+    /// <returns>The created instance</returns>
+    public object With(Type implementationType)
+    {
+        object instance = CreateInstance(implementationType);
+        Use(implementationType, instance);
+        return instance;
+    }
 
     #endregion Use
 


### PR DESCRIPTION
This cleans up test, and prevent the caller from immediately needing to go and retrieve the instance that we just created for them.