### PR TITLE
When CreateInstance fails include the reasons why

### DIFF
--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
+using System.Text;
 using Moq.AutoMock.Resolvers;
 using Moq.Language;
 using Moq.Language.Flow;
@@ -220,9 +221,9 @@ public partial class AutoMocker : IServiceProvider
         var context = new ObjectGraphContext(enablePrivate);
         if (!TryGetConstructorInvocation(type, context, out ConstructorInfo? ctor, out IInstance[]? arguments))
         {
-            throw new ArgumentException(
+            throw new ObjectCreationException(
                 $"Did not find a best constructor for `{type}`. If any type in the hierarchy has a non-public constructor, set the 'enablePrivate' parameter to true for this {nameof(AutoMocker)} method.",
-                nameof(type));
+                context.DiagnosticMessages);
         }
 
         try
@@ -1000,14 +1001,14 @@ public partial class AutoMocker : IServiceProvider
         [NotNullWhen(true)] out ConstructorInfo? constructor,
         [NotNullWhen(true)] out IInstance[]? arguments)
     {
-        IEnumerable<ConstructorInfo> ctors = type
+        IEnumerable<ConstructorInfo> constructors = type
             .GetConstructors(context.BindingFlags)
             .OrderByDescending(x => x.GetParameters().Length)
             .Concat(new[] { Empty(type) })
             .Where(x => x is not null)!;
 
         context.VisitedTypes.Add(type);
-        foreach (var ctor in ctors)
+        foreach (var ctor in constructors)
         {
             if (TryCreateArguments(ctor, context, out IInstance[] args))
             {
@@ -1033,6 +1034,7 @@ public partial class AutoMocker : IServiceProvider
                 ObjectGraphContext parameterContext = new(context);
                 if (!TryGet(parameters[i].ParameterType, parameterContext, out IInstance? service))
                 {
+                    context.AddDiagnosticMessage($"Rejecting constructor {GetConstructorDisplayString(constructor)}, because {nameof(AutoMocker)} was unable to create parameter '{parameters[i].ParameterType.FullName} {parameters[i].Name}'");
                     return false;
                 }
 
@@ -1042,6 +1044,26 @@ public partial class AutoMocker : IServiceProvider
             return true;
         }
 
+        static string GetConstructorDisplayString(ConstructorInfo constructor)
+        {
+            StringBuilder sb = new();
+            sb.Append(constructor.DeclaringType?.FullName);
+            sb.Append("(");
+            ParameterInfo[] parameters = constructor.GetParameters();
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                sb.Append(parameters[i].ParameterType.FullName);
+                sb.Append(' ');
+                sb.Append(parameters[i].Name);
+                if (i < parameters.Length - 1)
+                {
+                    sb.Append(", ");
+                }
+            }
+            sb.Append(")");
+
+            return sb.ToString();
+        }
     }
 
     private void EnsureCached(Type type, IInstance instance)

--- a/Moq.AutoMock/ObjectCreationException.cs
+++ b/Moq.AutoMock/ObjectCreationException.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Moq.AutoMock;
+
+/// <summary>
+/// This exception is thrown when the <see cref="AutoMocker"/> is unable to create an instance of a type.
+/// </summary>
+public class ObjectCreationException : Exception
+{
+    /// <summary>
+    /// A list of diagnostic messages indicating why the object could not be created.
+    /// </summary>
+    public IReadOnlyList<string> DiagnosticMessages { get; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Default constructor for <see cref="ObjectCreationException"/>.
+    /// </summary>
+    /// <param name="diagnosticMessages">A list of diagnostic messages</param>
+    public ObjectCreationException(IReadOnlyList<string> diagnosticMessages)
+    {
+        DiagnosticMessages = diagnosticMessages ?? throw new ArgumentNullException(nameof(diagnosticMessages));
+    }
+
+    /// <summary>
+    /// Constructor for <see cref="ObjectCreationException"/>.
+    /// </summary>
+    /// <param name="message">The exception message</param>
+    /// <param name="diagnosticMessages">A list of diagnostic messages</param>
+    public ObjectCreationException(string message, IReadOnlyList<string> diagnosticMessages) : base(message)
+    {
+        DiagnosticMessages = diagnosticMessages ?? throw new ArgumentNullException(nameof(diagnosticMessages));
+    }
+
+    /// <summary>
+    /// Constructor for <see cref="ObjectCreationException"/>.
+    /// </summary>
+    /// <param name="message">The exception message</param>
+    /// <param name="innerException">The inner exception</param>
+    /// <param name="diagnosticMessages">A list of diagnostic messages</param>
+    public ObjectCreationException(string message, Exception innerException, IReadOnlyList<string> diagnosticMessages) : base(message, innerException)
+    {
+        DiagnosticMessages = diagnosticMessages ?? throw new ArgumentNullException(nameof(diagnosticMessages));
+    }
+
+    /// <summary>
+    /// Serialization constructor for <see cref="ObjectCreationException"/>.
+    /// </summary>
+    /// <param name="info"></param>
+    /// <param name="context"></param>
+    protected ObjectCreationException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+    }
+}

--- a/Moq.AutoMock/ObjectGraphContext.cs
+++ b/Moq.AutoMock/ObjectGraphContext.cs
@@ -7,6 +7,8 @@ namespace Moq.AutoMock;
 /// </summary>
 public class ObjectGraphContext
 {
+    private List<string>? _diagnostics;
+
     /// <summary>
     /// Creates an instance with binding flags set according to `enablePrivate`.
     /// </summary>
@@ -43,7 +45,20 @@ public class ObjectGraphContext
     /// </summary>
     public HashSet<Type> VisitedTypes { get; }
 
+    /// <summary>
+    /// A list of diagnostic messages.
+    /// </summary>
+    public IReadOnlyList<string> DiagnosticMessages => _diagnostics ?? (IReadOnlyList<string>)Array.Empty<string>();
 
+    /// <summary>
+    /// Add a new diagnostic message to this context.
+    /// </summary>
+    /// <param name="message">The message to be added</param>
+    public void AddDiagnosticMessage(string message)
+    {
+        _diagnostics ??= new();
+        _diagnostics.Add(message);
+    }
 
     private static BindingFlags GetBindingFlags(bool enablePrivate)
     {


### PR DESCRIPTION
Right now when CreateInstance fails it can be difficult to know why. This is especially true when object graphs and custom resolves are at play. This adds diagnostic messages to the exception that is thrown so that people can see which parameters were unable to be constructed.