### PR TITLE
Prevent sealed class mocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 /.vs
+*.idea/
 
 bin/
 obj/

--- a/Moq.AutoMock.Tests/DescribeCreateInstance.cs
+++ b/Moq.AutoMock.Tests/DescribeCreateInstance.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿
 using Moq.AutoMock.Resolvers;
-using Moq.AutoMock.Tests.Util;
 
 namespace Moq.AutoMock.Tests;
 
@@ -208,7 +206,7 @@ public class DescribeCreateInstance
     public void It_includes_reason_why_nested_constructor_was_rejected()
     {
         AutoMocker mocker = new();
-        //Need to remove this resolver to prevent AM from attempting to simply mock the values (which will throw a Moq exception)
+        //Need to remove these resolvers to prevent AM from attempting to simply mock the values (which will throw a Moq exception), or create an instance
         mocker.Resolvers.Remove(mocker.Resolvers.OfType<MockResolver>().Single());
 
         ObjectCreationException ex = Assert.ThrowsException<ObjectCreationException>(() => mocker.CreateInstance<HasMultipleConstructors>());
@@ -216,6 +214,16 @@ public class DescribeCreateInstance
         Assert.AreEqual(2, ex.DiagnosticMessages.Count);
         Assert.AreEqual("Rejecting constructor Moq.AutoMock.Tests.DescribeCreateInstance+HasMultipleConstructors(Moq.AutoMock.Tests.DescribeCreateInstance+HasMultipleConstructorsNested nested), because AutoMocker was unable to create parameter 'Moq.AutoMock.Tests.DescribeCreateInstance+HasMultipleConstructorsNested nested'", ex.DiagnosticMessages[0]);
         Assert.AreEqual("Rejecting constructor Moq.AutoMock.Tests.DescribeCreateInstance+HasMultipleConstructors(Moq.AutoMock.Tests.DescribeCreateInstance+HasStringParameter hasString), because AutoMocker was unable to create parameter 'Moq.AutoMock.Tests.DescribeCreateInstance+HasStringParameter hasString'", ex.DiagnosticMessages[1]);
+    }
+
+    [TestMethod]
+    public void It_can_create_instances_of_nested_sealed_classes()
+    {
+        AutoMocker mocker = new();
+        mocker.Resolvers.Add(new InstanceResolver());
+        var mockWithSealedService = mocker.CreateInstance<HasNestedSealedService>();
+
+        Assert.AreEqual(mockWithSealedService.SealedService, mockWithSealedService.NestedSealedService.SealedService);
     }
 
     private class CustomStringResolver : IMockResolver
@@ -264,6 +272,18 @@ public class DescribeCreateInstance
         public HasMultipleConstructorsNested(HasStringParameter hasString)
         {
             
+        }
+    }
+
+    public class HasNestedSealedService
+    {
+        public SealedService SealedService { get; set; }
+        public WithSealedService NestedSealedService { get; set; }
+
+        public HasNestedSealedService(SealedService sealedService, WithSealedService nestedSealedService)
+        {
+            SealedService = sealedService;
+            NestedSealedService = nestedSealedService;
         }
     }
 

--- a/Moq.AutoMock.Tests/DescribeCreateInstance.cs
+++ b/Moq.AutoMock.Tests/DescribeCreateInstance.cs
@@ -206,7 +206,7 @@ public class DescribeCreateInstance
     public void It_includes_reason_why_nested_constructor_was_rejected()
     {
         AutoMocker mocker = new();
-        //Need to remove these resolvers to prevent AM from attempting to simply mock the values (which will throw a Moq exception), or create an instance
+        //Need to remove this resolver to prevent AM from attempting to simply mock the values (which will throw a Moq exception)
         mocker.Resolvers.Remove(mocker.Resolvers.OfType<MockResolver>().Single());
 
         ObjectCreationException ex = Assert.ThrowsException<ObjectCreationException>(() => mocker.CreateInstance<HasMultipleConstructors>());

--- a/Moq.AutoMock.Tests/DescribeGetMock.cs
+++ b/Moq.AutoMock.Tests/DescribeGetMock.cs
@@ -82,4 +82,12 @@ public class DescribeGetMock
         var service = mocker.GetService(typeof(string));
         Assert.IsNull(service);
     }
+
+    [TestMethod]
+    public void It_throws_when_mocking_a_sealed_class()
+    {
+        var mocker = new AutoMocker();
+        var act = () => mocker.GetMock<SealedService>();
+        Assert.ThrowsException<ArgumentException>(act);
+    }
 }

--- a/Moq.AutoMock.Tests/Util/SealedService.cs
+++ b/Moq.AutoMock.Tests/Util/SealedService.cs
@@ -1,0 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Moq.AutoMock.Tests.Util;
+
+[ExcludeFromCodeCoverage]
+public sealed class SealedService
+{
+    public SealedService() { }
+}

--- a/Moq.AutoMock.Tests/Util/WithSealedService.cs
+++ b/Moq.AutoMock.Tests/Util/WithSealedService.cs
@@ -1,0 +1,14 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Moq.AutoMock.Tests.Util;
+
+[ExcludeFromCodeCoverage]
+public class WithSealedService
+{
+    public SealedService SealedService { get; set; }
+
+    public WithSealedService(SealedService service)
+    {
+        SealedService = service;
+    }
+}

--- a/Moq.AutoMock/Resolvers/InstanceResolver.cs
+++ b/Moq.AutoMock/Resolvers/InstanceResolver.cs
@@ -1,0 +1,19 @@
+namespace Moq.AutoMock.Resolvers;
+
+/// <summary>
+/// A resolver that resolves requested types with a created instance.
+/// </summary>
+public class InstanceResolver : IMockResolver
+{
+    /// <summary>
+    /// Resolves requested types with created instances.
+    /// </summary>
+    /// <param name="context">The resolution context.</param>
+    public void Resolve(MockResolutionContext context)
+    {
+        if (context.AutoMocker.CreateInstanceInternal(context.RequestType, context.ObjectGraphContext) is { } instance)
+        {
+            context.Value = instance;
+        }
+    }
+}


### PR DESCRIPTION
+ Prevents sealed classes from being mocked with getMock
+ Added an instanceResolver for creating instances. Allows nested sealed classes to be instantiated when creating parent instance
 + New resolver is not added to the default resolver list.