### PR TITLE
fix: Add `ContinuousIntegrationBuild` argument to the `dotnet pack` command

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -51,7 +51,7 @@ jobs:
           $env:VersionSuffix = 'ci{0:0000}' -f ${{ github.run_number }}
         }
 
-        dotnet pack --configuration Release --verbosity normal --output .
+        dotnet pack /p:ContinuousIntegrationBuild=true --configuration Release --verbosity normal --output . 
     
     - name: Upload NuGet
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fixes #274

Could also go the route of adding this into the `Directory.Build.props`, not sure what is preferable.


```csproj
  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
  	<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
  </PropertyGroup>
```