### PR TITLE
feat: Change return type on WithSelfMock

### DIFF
--- a/Moq.AutoMock.Tests/DescribeWithSelfMock.cs
+++ b/Moq.AutoMock.Tests/DescribeWithSelfMock.cs
@@ -12,7 +12,7 @@ public class DescribeWithSelfMock
 
         var mock = mocker.WithSelfMock<IService2, Service2>(defaultValue: DefaultValue.Custom, defaultValueProvider: provider);
 
-        Assert.AreEqual(provider, Mock.Get(mock).DefaultValueProvider);
+        Assert.AreEqual(provider, mock.DefaultValueProvider);
     }
 
     [TestMethod]
@@ -24,7 +24,7 @@ public class DescribeWithSelfMock
 
         var mock = mocker.WithSelfMock<IService2, Service2>();
 
-        Assert.AreEqual(provider, Mock.Get(mock).DefaultValueProvider);
+        Assert.AreEqual(provider, mock.DefaultValueProvider);
     }
 
     [TestMethod]
@@ -97,6 +97,15 @@ public class DescribeWithSelfMock
         var mock = (Service2)mocker.WithSelfMock(typeof(Service2));
 
         Assert.AreEqual(provider, Mock.Get(mock).DefaultValueProvider);
+    }
+
+    [TestMethod]
+    public void WithSelfMock_returns_mock_of_service()
+    {
+        var mocker = new AutoMocker();
+        var mockService = mocker.WithSelfMock<IService2, Service2>();
+
+        Assert.IsInstanceOfType<Mock<IService2>>(mockService);
     }
 }
 

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -320,12 +320,15 @@ public partial class AutoMocker : IServiceProvider
             defaultValue ?? DefaultValue,
             defaultValueProvider ?? DefaultValueProvider,
             callBase ?? CallBase);
+
+        Mock<TService> serviceMock = selfMock.As<TService>();
+
         WithTypeMap(typeMap =>
         {
             typeMap[typeof(TImplementation)] = new MockInstance(selfMock);
-            typeMap[typeof(TService)] = new MockInstance(selfMock.As<TService>());
+            typeMap[typeof(TService)] = new MockInstance(serviceMock);
         });
-        return selfMock.As<TService>();
+        return serviceMock;
     }
 
     /// <summary>

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -304,8 +304,8 @@ public partial class AutoMocker : IServiceProvider
     /// <param name="defaultValue">Sets the DefaultValue property on the created Mock.</param>
     /// <param name="defaultValueProvider">The instance that will be used to produce default return values for unexpected invocations.</param>
     /// <param name="callBase">Sets the CallBase property on the created Mock.</param>
-    /// <returns>An instance with virtual and abstract members mocked</returns> 
-    public TImplementation WithSelfMock<TService, TImplementation>(
+    /// <returns>A mock of the service</returns> 
+    public Mock<TService> WithSelfMock<TService, TImplementation>(
         bool enablePrivate = false,
         MockBehavior? mockBehavior = null,
         DefaultValue? defaultValue = null,
@@ -325,7 +325,7 @@ public partial class AutoMocker : IServiceProvider
             typeMap[typeof(TImplementation)] = new MockInstance(selfMock);
             typeMap[typeof(TService)] = new MockInstance(selfMock.As<TService>());
         });
-        return selfMock.Object;
+        return selfMock.As<TService>();
     }
 
     /// <summary>


### PR DESCRIPTION
This is a proposal as well as showing it.

This is all based on my assumption of how AutoMocker works :)
I think returning the mocked service here makes more sense than the object of the implementation.
1. Having the actual instance only helps if I am about to go use the concrete type after (saving me one line of code at most).
ex: 
```C#
var implementedObject = Mocker.WithSelfMock<IStorage, RealStorage>();
foo.TryRenameAsync(implementedObject, newName))
```
But could be achieved by doing this in the new format:
```C#
var serviceMock = Mocker.WithSelfMock<IStorage, RealStorage>();
foo.TryRenameAsync(serviceMock.Object, newName))
```
2. With the mock service, I can then so do a setup that I couldn't do immediately with the implemented object.
before:
```C#
Mocker.WithSelfMock<IStorage, RealStorage>();
Mock<IStorage> mock = Mocker.GetMock<IStorage>();
mock.Setup(mock => mock.DoThing(name)).ReturnsAsync("Did Something");
foo.TryRenameAsync(mock.Object, newName))
```
can now be:
```C#
Mock<IStorage> mock = Mocker.WithSelfMock<IStorage, RealStorage>();
mock.Setup(mock => mock.DoThing(name)).ReturnsAsync("Did Something");
foo.TryRenameAsync(mock.Object, newName))
```
3. The user doesn't loose out from the `serviceMock` being able to represent the concrete class, and can still call it if call base is passed in.
```C#
Mock<IStorage> mock = Mocker.WithSelfMock<IStorage, RealStorage>(callBase: true);
mock.Setup(mock => mock.DoThing(name)).ReturnsAsync("Did Something");
foo.TryRenameAsync(mock.Object, newName))
```