### PR TITLE
Allow to chain calls of the 'AutoMocker.Use' method

### DIFF
--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -453,7 +453,8 @@ public partial class AutoMocker : IServiceProvider
     /// </summary>
     /// <typeparam name="TService">The type that the instance will be registered as</typeparam>
     /// <param name="service"></param>
-    public void Use<TService>(TService? service)
+    /// <returns>Itself</returns>
+    public AutoMocker Use<TService>(TService? service)
         => Use(typeof(TService), service);
 
     /// <summary>
@@ -461,7 +462,8 @@ public partial class AutoMocker : IServiceProvider
     /// </summary>
     /// <param name="type">The type of service to use</param>
     /// <param name="service">The service to use</param>
-    public void Use(Type type, object? service)
+    /// <returns>Itself</returns>
+    public AutoMocker Use(Type type, object? service)
     {
         if (type is null) throw new ArgumentNullException(nameof(type));
         if (service != null && !type.IsInstanceOfType(service))
@@ -478,6 +480,8 @@ public partial class AutoMocker : IServiceProvider
             }
             typeMap[type] = new RealInstance(service);
         });
+
+        return this;
     }
 
     /// <summary>
@@ -485,7 +489,8 @@ public partial class AutoMocker : IServiceProvider
     /// </summary>
     /// <typeparam name="TService">The type that the instance will be registered as</typeparam>
     /// <param name="mockedService">The mocked service</param>
-    public void Use<TService>(Mock<TService> mockedService)
+    /// <returns>Itself</returns>
+    public AutoMocker Use<TService>(Mock<TService> mockedService)
         where TService : class
     {
         WithTypeMap(typeMap =>
@@ -499,6 +504,8 @@ public partial class AutoMocker : IServiceProvider
             }
             typeMap[serviceType] = new MockInstance(mockedService ?? throw new ArgumentNullException(nameof(mockedService)));
         });
+
+        return this;
     }
 
     /// <summary>
@@ -506,12 +513,13 @@ public partial class AutoMocker : IServiceProvider
     /// </summary>
     /// <typeparam name="TService">The type that the instance will be registered as</typeparam>
     /// <param name="setup">A shortcut for Mock.Of's syntax</param>
-    public void Use<TService>(Expression<Func<TService, bool>> setup)
+    /// <returns>Itself</returns>
+    public AutoMocker Use<TService>(Expression<Func<TService, bool>> setup)
         where TService : class
     {
         if (setup is null) throw new ArgumentNullException(nameof(setup));
 
-        Use(Mock.Get(Mock.Of(setup)));
+        return Use(Mock.Get(Mock.Of(setup)));
     }
 
     /// <summary>


### PR DESCRIPTION
A tiny change that enables builder pattern and allows to chain calls of the `Use` method.
Example of usage
```
    public interface IDependencyOne { void Foo(); }
    public interface IDependencyTwo { void Bar(); }

    public class DependencyUser(IDependencyOne dependencyOne, IDependencyTwo dependencyTwo)
    {
        readonly IDependencyOne _dependencyOne = dependencyOne ?? throw new ArgumentNullException(nameof(dependencyOne));
        readonly IDependencyTwo _dependencyTwo = dependencyTwo ?? throw new ArgumentNullException(nameof(dependencyTwo));

        public void FooBar()
        {
            _dependencyOne.Foo();
            _dependencyTwo.Bar();
            throw new InvalidOperationException();
        }
    }

    [TestMethod]
    public void ChainUseExample()
    {
        var testService = new AutoMocker()
            .Use(Mock.Of<IDependencyOne>())
            .Use(Mock.Of<IDependencyTwo>())
            .CreateInstance<DependencyUser>();

        Assert.ThrowsException<InvalidOperationException>(() => testService.FooBar());
    }
```