### PR TITLE
Adds support for callback-based service resolution

### DIFF
--- a/Moq.AutoMock.Tests/DescribeUsingExplicitObjects.cs
+++ b/Moq.AutoMock.Tests/DescribeUsingExplicitObjects.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq.AutoMock.Resolvers;
-using Moq.AutoMock.Tests.Util;
+﻿using Moq.AutoMock.Resolvers;
 
 namespace Moq.AutoMock.Tests;
 

--- a/Moq.AutoMock.Tests/DescribeUsingWithCallback.cs
+++ b/Moq.AutoMock.Tests/DescribeUsingWithCallback.cs
@@ -1,0 +1,54 @@
+﻿namespace Moq.AutoMock.Tests;
+
+[TestClass]
+public class DescribeUsingWithCallback
+{
+    [TestMethod]
+    public void You_can_register_a_callback_to_configure_a_mock()
+    {
+        AutoMocker mocker = new();
+        mocker.Use<IService2>(mocker =>
+        {
+            return new Service2();
+        });
+        
+        var instance = mocker.Get<IService2>();
+        Assert.IsInstanceOfType(instance, typeof(Service2));
+    }
+
+    [TestMethod]
+    public void Service_callback_is_not_invoked_until_the_service_is_requested()
+    {
+        AutoMocker mocker = new();
+        bool callbackInvoked = false;
+        mocker.Use<IService2>(mocker =>
+        {
+            callbackInvoked = true;
+            return new Service2();
+        });
+
+        
+        bool beforeRequest = callbackInvoked;
+        _ = mocker.CreateInstance<WithService>();
+
+        Assert.IsFalse(beforeRequest, "Callback should not have been invoked yet.");
+        Assert.IsTrue(callbackInvoked, "Callback should have been invoked when the service was requested.");
+    }
+
+    [TestMethod]
+    public void Service_created_from_a_callback_is_cached()
+    {
+        AutoMocker mocker = new();
+        int callbackCount = 0;
+        mocker.Use<IService2>(() =>
+        {
+            callbackCount++;
+            return new Service2();
+        });
+
+        _ = mocker.CreateInstance<WithService>();
+        _ = mocker.CreateInstance<WithService>();
+        
+        Assert.AreEqual(1, callbackCount);
+    }
+}

--- a/Moq.AutoMock/Resolvers/CallbackResolver.cs
+++ b/Moq.AutoMock/Resolvers/CallbackResolver.cs
@@ -1,0 +1,29 @@
+﻿namespace Moq.AutoMock.Resolvers;
+
+/// <summary>
+/// Contains all of the callbacks registered with AutoMocker.
+/// </summary>
+public class CallbackResolver : IMockResolver
+{
+    private NonBlocking.ConcurrentDictionary<Type, Func<AutoMocker, object?>> CallbackMap { get; } = new();
+
+    /// <inheritdoc />
+    public void Resolve(MockResolutionContext context)
+    {
+        if (CallbackMap.TryGetValue(context.RequestType, out Func<AutoMocker, object?>? callback))
+        {
+            context.Value = callback(context.AutoMocker);
+        }
+    }
+
+
+    /// <summary>
+    /// Adds a callback to the resolver.
+    /// </summary>
+    /// <typeparam name="TService">The service type.</typeparam>
+    /// <param name="callback">The callback to register.</param>
+    public void AddCallback<TService>(Func<AutoMocker, TService?> callback)
+    {
+        CallbackMap[typeof(TService)] = am => callback(am);
+    }
+}


### PR DESCRIPTION
Introduces new `Use` overloads that accept factory delegates for registering services. These callbacks enable lazy instantiation and caching of service instances, invoked only when the service is first requested.

A new `CallbackResolver` manages and executes these factory functions. This provides a flexible way to configure service creation with deferred execution and ensures that services created via callback are cached for subsequent requests.

Fixes: #196
