### PR TITLE
Consolidates Dependabot GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,4 +16,8 @@ updates:
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly" 
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*" 


### PR DESCRIPTION
Configures Dependabot to group all GitHub Actions dependency updates into a single pull request. This reduces PR clutter and simplifies dependency management by allowing related updates to be reviewed and merged together.
