### PR TITLE
Enables manual NuGet publish workflow

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -99,7 +99,7 @@ jobs:
 
   # Publish to NuGet and GitHub Packages
     - name: Publish
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
       run: |
         dotnet nuget push *.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_TOKEN }} --skip-duplicate
         dotnet nuget push *.nupkg `


### PR DESCRIPTION
Allows maintainers to trigger the package publishing process on demand. This provides greater flexibility for releases or re-publishing without requiring a new code push.
