### PR TITLE
Updates duplicate service error message

### DIFF
--- a/Moq.AutoMock.Tests/DescribeUsingExplicitObjects.cs
+++ b/Moq.AutoMock.Tests/DescribeUsingExplicitObjects.cs
@@ -90,7 +90,7 @@ public class DescribeUsingExplicitObjects
         Service2 service = new();
         mocker.Use(service);
         var ex = Assert.Throws<InvalidOperationException>(() => mocker.Use(service));
-        Assert.AreEqual("The service has already been added.", ex.Message);
+        Assert.AreEqual($"The service instance has already been added. You can safely remove this call to AutoMocker.Use", ex.Message);
     }
 
     [TestMethod]

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -481,7 +481,7 @@ public partial class AutoMocker : IServiceProvider
                 existingInstance is RealInstance realInstance &&
                 Equals(realInstance.Value, service))
             {
-                throw new InvalidOperationException("The service has already been added.");
+                throw new InvalidOperationException($"The service instance has already been added. You can safely remove this call to {nameof(AutoMocker)}.{nameof(Use)}");
             }
             typeMap[type] = new RealInstance(service);
         });


### PR DESCRIPTION
The exception message when adding a duplicate service instance now suggests removing the redundant `AutoMocker.Use` call.
