### PR TITLE
Relaxes WithOptions generic constraint for required properties

### DIFF
--- a/GeneratorTests/Moq.AutoMock.Generator.Example.MSTest/ControllerWithOptionsTests.cs
+++ b/GeneratorTests/Moq.AutoMock.Generator.Example.MSTest/ControllerWithOptionsTests.cs
@@ -7,10 +7,15 @@ public class ControllerWithOptionsTests
     {
         AutoMocker mocker = new();
         
-        mocker.WithOptions<TestsOptions>(options => options.Number = 42);
+        mocker.WithOptions<TestsOptions>(options => 
+        {
+            options.Number = 42;
+            options.Required = "Some Value";
+        });
 
         ControllerWithOptions controller = mocker.CreateInstance<ControllerWithOptions>();
 
         Assert.AreEqual(42, controller.Options.Value.Number);
+        Assert.AreEqual("Some Value", controller.Options.Value.Required);
     }
 }

--- a/GeneratorTests/Moq.AutoMock.Generator.Example.NUnit/ControllerWithOptionsTests.cs
+++ b/GeneratorTests/Moq.AutoMock.Generator.Example.NUnit/ControllerWithOptionsTests.cs
@@ -8,10 +8,15 @@ public class ControllerWithOptionsTests
     {
         AutoMocker mocker = new();
         
-        mocker.WithOptions<TestsOptions>(options => options.Number = 42);
+        mocker.WithOptions<TestsOptions>(options => 
+        {
+            options.Number = 42;
+            options.Required = "Some Value";
+        });
 
         ControllerWithOptions controller = mocker.CreateInstance<ControllerWithOptions>();
 
         Assert.That(42 == controller.Options.Value.Number);
+        Assert.That("Some Value" == controller.Options.Value.Required);
     }
 }

--- a/GeneratorTests/Moq.AutoMock.Generator.Example.TUnit/ControllerWithOptionsTests.cs
+++ b/GeneratorTests/Moq.AutoMock.Generator.Example.TUnit/ControllerWithOptionsTests.cs
@@ -7,10 +7,15 @@ public partial class ControllerWithOptionsTests
     {
         AutoMocker mocker = new();
 
-        mocker.WithOptions<TestsOptions>(options => options.Number = 42);
+        mocker.WithOptions<TestsOptions>(options =>
+        {
+            options.Number = 42;
+            options.Required = "Some Value";
+        });
 
         ControllerWithOptions controller = mocker.CreateInstance<ControllerWithOptions>();
 
         await Assert.That(controller.Options.Value.Number).IsEqualTo(42);
+        await Assert.That(controller.Options.Value.Required).IsEqualTo("Some Value");
     }
 }

--- a/GeneratorTests/Moq.AutoMock.Generator.Example.xUnit/ControllerWithOptionsTests.cs
+++ b/GeneratorTests/Moq.AutoMock.Generator.Example.xUnit/ControllerWithOptionsTests.cs
@@ -7,11 +7,16 @@ public class ControllerWithOptionsTests
     public void CreateInstance_WithOptions_EmbedsOptions()
     {
         AutoMocker mocker = new();
-        
-        mocker.WithOptions<TestsOptions>(options => options.Number = 42);
+
+        mocker.WithOptions<TestsOptions>(options =>
+        {
+            options.Number = 42;
+            options.Required = "Some Value";
+        });
 
         ControllerWithOptions controller = mocker.CreateInstance<ControllerWithOptions>();
 
         Assert.Equal(42, controller.Options.Value.Number);
+        Assert.Equal("Some Value", controller.Options.Value.Required);
     }
 }

--- a/GeneratorTests/Moq.AutoMocker.Generator.Example/TestsOptions.cs
+++ b/GeneratorTests/Moq.AutoMocker.Generator.Example/TestsOptions.cs
@@ -3,4 +3,5 @@
 public class TestsOptions
 {
     public int Number { get; set; }
+    public required string Required { get; set; }
 }

--- a/Moq.AutoMocker.Generators.Tests/OptionsGeneratorTests.cs
+++ b/Moq.AutoMocker.Generators.Tests/OptionsGeneratorTests.cs
@@ -32,7 +32,7 @@ public class OptionsGeneratorTests
                 /// <typeparam name="TClass">The type of Options being configured.</typeparam>
                 /// <returns>The same <see cref="AutoMocker"/> instance passed as parameter, allowing chained calls.</returns>
                 public static AutoMocker WithOptions<TClass>(this AutoMocker mocker, Action<TClass>? configure = null)
-                    where TClass : class, new()
+                    where TClass : class
                 {
                     if (mocker == null)
                     {

--- a/Moq.AutoMocker.Generators/OptionsExtensionSourceGenerator.cs
+++ b/Moq.AutoMocker.Generators/OptionsExtensionSourceGenerator.cs
@@ -74,7 +74,7 @@ public sealed class OptionsExtensionSourceGenerator : IIncrementalGenerator
                 /// <typeparam name="TClass">The type of Options being configured.</typeparam>
                 /// <returns>The same <see cref="AutoMocker"/> instance passed as parameter, allowing chained calls.</returns>
                 public static AutoMocker WithOptions<TClass>(this AutoMocker mocker, Action<TClass>? configure = null)
-                    where TClass : class, new()
+                    where TClass : class
                 {
                     if (mocker == null)
                     {


### PR DESCRIPTION
Adds a required property to TestsOptions and updates test cases. Updates the `WithOptions` generic type constraint to remove `new()` for better compatibility with types containing `required` members.
