### PR TITLE
Renames `AddApplicationInsights` to `WithApplicationInsights`

### DIFF
--- a/Moq.AutoMock.Tests/DescribeApplicationInsights.cs
+++ b/Moq.AutoMock.Tests/DescribeApplicationInsights.cs
@@ -7,10 +7,10 @@ namespace Moq.AutoMock.Tests;
 public class DescribeApplicationInsights
 {
     [TestMethod]
-    public void AddApplicationInsights_AllowsVerificationOfTrackedEvents()
+    public void WithApplicationInsights_AllowsVerificationOfTrackedEvents()
     {
         var mocker = new AutoMocker();
-        mocker.AddApplicationInsights();
+        mocker.WithApplicationInsights();
 
         var service = mocker.CreateInstance<ServiceWithApplicationInsights>();
 
@@ -28,10 +28,10 @@ public class DescribeApplicationInsights
     }
 
     [TestMethod]
-    public void AddApplicationInsights_AllowsVerificationOfTrackedMetrics()
+    public void WithApplicationInsights_AllowsVerificationOfTrackedMetrics()
     {
         var mocker = new AutoMocker();
-        mocker.AddApplicationInsights();
+        mocker.WithApplicationInsights();
 
         var service = mocker.CreateInstance<ServiceWithApplicationInsights>();
 
@@ -56,7 +56,7 @@ public class DescribeApplicationInsights
     public void GetSentTelemetry_ReturnsAllSentTelemetryItems()
     {
         var mocker = new AutoMocker();
-        mocker.AddApplicationInsights();
+        mocker.WithApplicationInsights();
 
         var service = mocker.CreateInstance<ServiceWithApplicationInsights>();
 

--- a/Moq.AutoMocker.Generators.Tests/ApplicationInsightsGeneratorTests.cs
+++ b/Moq.AutoMocker.Generators.Tests/ApplicationInsightsGeneratorTests.cs
@@ -35,7 +35,7 @@ public class ApplicationInsightsGeneratorTests
                 /// </summary>
                 /// <param name="mocker">The <see cref="AutoMocker"/> instance.</param>
                 /// <returns>The same <see cref="AutoMocker"/> instance passed as parameter, allowing chained calls.</returns>
-                public static AutoMocker AddApplicationInsights(this AutoMocker mocker)
+                public static AutoMocker WithApplicationInsights(this AutoMocker mocker)
                 {
                     if (mocker == null)
                     {
@@ -66,12 +66,12 @@ public class ApplicationInsightsGeneratorTests
 
                 /// <summary>
                 /// Gets the collection of telemetry items that have been sent through the Application Insights TelemetryClient.
-                /// This method retrieves telemetry from the <see cref="FakeTelemetryChannel"/> that was configured by <see cref="AddApplicationInsights"/>.
+                /// This method retrieves telemetry from the <see cref="FakeTelemetryChannel"/> that was configured by <see cref="WithApplicationInsights"/>.
                 /// </summary>
                 /// <param name="mocker">The <see cref="AutoMocker"/> instance.</param>
                 /// <returns>A read-only list of telemetry items that have been sent.</returns>
                 /// <exception cref="ArgumentNullException">Thrown when <paramref name="mocker"/> is null.</exception>
-                /// <exception cref="InvalidOperationException">Thrown when Application Insights has not been configured using <see cref="AddApplicationInsights"/>.</exception>
+                /// <exception cref="InvalidOperationException">Thrown when Application Insights has not been configured using <see cref="WithApplicationInsights"/>.</exception>
                 public static IReadOnlyList<ITelemetry> GetSentTelemetry(this AutoMocker mocker)
                 {
                     if (mocker == null)
@@ -82,7 +82,7 @@ public class ApplicationInsightsGeneratorTests
                     var channel = mocker.Get<FakeTelemetryChannel>();
                     if (channel == null)
                     {
-                        throw new InvalidOperationException("Application Insights has not been configured. Call AddApplicationInsights() first.");
+                        throw new InvalidOperationException("Application Insights has not been configured. Call WithApplicationInsights() first.");
                     }
 
                     return channel.SentItems;

--- a/Moq.AutoMocker.Generators/ApplicationInsightsExtensionSourceGenerator.cs
+++ b/Moq.AutoMocker.Generators/ApplicationInsightsExtensionSourceGenerator.cs
@@ -78,7 +78,7 @@ public sealed class ApplicationInsightsExtensionSourceGenerator : IIncrementalGe
                 /// </summary>
                 /// <param name="mocker">The <see cref="AutoMocker"/> instance.</param>
                 /// <returns>The same <see cref="AutoMocker"/> instance passed as parameter, allowing chained calls.</returns>
-                public static AutoMocker AddApplicationInsights(this AutoMocker mocker)
+                public static AutoMocker WithApplicationInsights(this AutoMocker mocker)
                 {
                     if (mocker == null)
                     {
@@ -109,12 +109,12 @@ public sealed class ApplicationInsightsExtensionSourceGenerator : IIncrementalGe
 
                 /// <summary>
                 /// Gets the collection of telemetry items that have been sent through the Application Insights TelemetryClient.
-                /// This method retrieves telemetry from the <see cref="FakeTelemetryChannel"/> that was configured by <see cref="AddApplicationInsights"/>.
+                /// This method retrieves telemetry from the <see cref="FakeTelemetryChannel"/> that was configured by <see cref="WithApplicationInsights"/>.
                 /// </summary>
                 /// <param name="mocker">The <see cref="AutoMocker"/> instance.</param>
                 /// <returns>A read-only list of telemetry items that have been sent.</returns>
                 /// <exception cref="ArgumentNullException">Thrown when <paramref name="mocker"/> is null.</exception>
-                /// <exception cref="InvalidOperationException">Thrown when Application Insights has not been configured using <see cref="AddApplicationInsights"/>.</exception>
+                /// <exception cref="InvalidOperationException">Thrown when Application Insights has not been configured using <see cref="WithApplicationInsights"/>.</exception>
                 public static IReadOnlyList<ITelemetry> GetSentTelemetry(this AutoMocker mocker)
                 {
                     if (mocker == null)
@@ -125,7 +125,7 @@ public sealed class ApplicationInsightsExtensionSourceGenerator : IIncrementalGe
                     var channel = mocker.Get<FakeTelemetryChannel>();
                     if (channel == null)
                     {
-                        throw new InvalidOperationException("Application Insights has not been configured. Call AddApplicationInsights() first.");
+                        throw new InvalidOperationException("Application Insights has not been configured. Call WithApplicationInsights() first.");
                     }
 
                     return channel.SentItems;


### PR DESCRIPTION
Refactors the extension method to better convey its intent as a configuration and setup helper for Application Insights within a fluent API style.

Updates method definitions, usage in tests, XML documentation, and generated code to reflect the new name.
