### PR TITLE
Refines Keyed Services Generator Dependency Check

### DIFF
--- a/Moq.AutoMock.slnx
+++ b/Moq.AutoMock.slnx
@@ -23,6 +23,17 @@
   <Folder Name="/Solution Items/.github/agents/">
     <File Path=".github/agents/source-generator-docs.md" />
   </Folder>
+  <Folder Name="/Solution Items/docs/">
+    <File Path="docs/Moq.AutoMock.md" />
+    <File Path="docs/SourceGenerators.md" />
+  </Folder>
+  <Folder Name="/Solution Items/docs/SourceGenerators/">
+    <File Path="docs/SourceGenerators/ApplicationInsightsExtensionGenerator.md" />
+    <File Path="docs/SourceGenerators/FakeLoggingExtensionGenerator.md" />
+    <File Path="docs/SourceGenerators/KeyedServicesExtensionGenerator.md" />
+    <File Path="docs/SourceGenerators/OptionsExtensionGenerator.md" />
+    <File Path="docs/SourceGenerators/UnitTestGenerator.md" />
+  </Folder>
   <Project Path="Generators/Generators.csproj" />
   <Project Path="Moq.AutoMock.Tests/Moq.AutoMock.Tests.csproj" />
   <Project Path="Moq.AutoMock/Moq.AutoMock.csproj" />

--- a/Moq.AutoMocker.Generators/KeyedServicesExtensionSourceGenerator.cs
+++ b/Moq.AutoMocker.Generators/KeyedServicesExtensionSourceGenerator.cs
@@ -44,9 +44,10 @@ public sealed class KeyedServicesExtensionSourceGenerator : IIncrementalGenerato
     {
         foreach (AssemblyIdentity assembly in assemblies)
         {
-            if (assembly.Name.StartsWith("Microsoft.Extensions.DependencyInjection"))
+            if (assembly.Name.StartsWith("Microsoft.Extensions.DependencyInjection.Abstractions"))
             {
-                return true;
+                // Keyed services were introduced in version 8.0
+                return assembly.Version.Major >= 8;
             }
         }
         return false;

--- a/docs/SourceGenerators/KeyedServicesExtensionGenerator.md
+++ b/docs/SourceGenerators/KeyedServicesExtensionGenerator.md
@@ -1,6 +1,6 @@
 # Keyed Services Extension Generator
 
-When your test project references `Microsoft.Extensions.DependencyInjection`, this generator creates `WithKeyedService<T>()` extension methods for `AutoMocker` that enable testing classes that depend on keyed services via `IKeyedServiceProvider`.
+When your test project references `Microsoft.Extensions.DependencyInjection.Abstractions` version 8.x or newer, this generator creates `WithKeyedService<T>()` extension methods for `AutoMocker` that enable testing classes that depend on keyed services via `IKeyedServiceProvider`.
 
 ## Features
 


### PR DESCRIPTION
Updates the Keyed Services source generator to accurately detect the presence of keyed services. It now specifically checks for a reference to `Microsoft.Extensions.DependencyInjection.Abstractions` version 8.x or newer, as keyed services were introduced in this version.

This prevents the generator from activating unnecessarily or incorrectly when older versions of the Dependency Injection abstractions are in use. Also, updates the related documentation to reflect this precise dependency requirement.