### PR TITLE
Fix usings in `OptionsExtensionSourceGenerator`

### DIFF
--- a/Moq.AutoMocker.Generators/OptionsExtensionSourceGenerator.cs
+++ b/Moq.AutoMocker.Generators/OptionsExtensionSourceGenerator.cs
@@ -59,6 +59,8 @@ public sealed class OptionsExtensionSourceGenerator : IIncrementalGenerator
         // Licensed under the MIT License. See LICENSE in the project root for license information.
         namespace Moq.AutoMock
         {
+            using System;
+            using System.Collections.Generic;
             using Microsoft.Extensions.Options;
 
             /// <summary>


### PR DESCRIPTION
The generated code uses `System.Action<>`, `System.ArgumentNullException` and `System.Collections.Generic.IEnumerable<>` but their namespaces were not included.

Fixes compilation errors introduced by the generated code in consuming projects.
ref. https://github.com/moq/Moq.AutoMocker/issues/402