### PR TITLE
Fixes #403: Adds required using directives

### DIFF
--- a/Moq.AutoMocker.Generators.Tests/OptionsGeneratorTests.cs
+++ b/Moq.AutoMocker.Generators.Tests/OptionsGeneratorTests.cs
@@ -17,6 +17,8 @@ public class OptionsGeneratorTests
         // Licensed under the MIT License. See LICENSE in the project root for license information.
         namespace Moq.AutoMock
         {
+            using System;
+            using System.Collections.Generic;
             using Microsoft.Extensions.Options;
 
             /// <summary>

--- a/Moq.AutoMocker.Generators/OptionsExtensionSourceGenerator.cs
+++ b/Moq.AutoMocker.Generators/OptionsExtensionSourceGenerator.cs
@@ -59,6 +59,8 @@ public sealed class OptionsExtensionSourceGenerator : IIncrementalGenerator
         // Licensed under the MIT License. See LICENSE in the project root for license information.
         namespace Moq.AutoMock
         {
+            using System;
+            using System.Collections.Generic;
             using Microsoft.Extensions.Options;
 
             /// <summary>


### PR DESCRIPTION
Ensures correct compilation and type resolution by adding essential `System` and `System.Collections.Generic` using directives to the OptionsGenerator project and its tests.

Fixes #403, #402