### PR TITLE
Clarifies Source Generator Ambiguities and Disabling

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,11 @@ car.Accelerate(42);
 // This method verifies all mocks in the container
 mocker.VerifyAll();
 ```
+
+Documentation
+=============
+
+For more detailed documentation, including information about the built-in source generators that can automatically generate test boilerplate code, see the [docs folder](docs/).
+
+- [AutoMocker API Reference](docs/Moq.AutoMock.md)
+- [Source Generators](docs/SourceGenerators.md) - Learn about automatic code generation for constructor tests, options configuration, logging, and more


### PR DESCRIPTION
Adds comprehensive documentation to clarify potential ambiguous method call errors that can occur when `Moq.AutoMock` source generators are enabled across multiple test projects with shared visibility.

Provides detailed instructions on:
- Why ambiguous reference issues occur (due to generated `internal partial` classes).
- Common scenarios leading to these errors.
- How to resolve these issues by disabling specific source generators using MSBuild properties in the `.csproj` file.

This update aims to improve user experience by addressing a common pain point and providing clear guidance for configuration.

Relates to #410