### PR TITLE
Upgrade core dependencies and align with Roslyn API changes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,26 +5,27 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.ApplicationInsights" Version="3.0.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.ApplicationInsights" Version="3.1.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.MSTest" Version="1.1.2" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.202" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.6.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="MSTest" Version="4.2.1" />
+    <PackageVersion Include="MSTest" Version="4.2.3" />
     <PackageVersion Include="NonBlocking" Version="2.1.2" />
-    <PackageVersion Include="NUnit" Version="4.5.1" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.2" />
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.0" />
-    <PackageVersion Include="System.Formats.Asn1" Version="9.0.10" />
-    <PackageVersion Include="TUnit" Version="1.37.0" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.8" />
+    <PackageVersion Include="System.Formats.Asn1" Version="10.0.8" />
+    <PackageVersion Include="TUnit" Version="1.46.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>

--- a/Moq.AutoMocker.Generators.Tests/ApplicationInsightsGeneratorTests.cs
+++ b/Moq.AutoMocker.Generators.Tests/ApplicationInsightsGeneratorTests.cs
@@ -246,7 +246,7 @@ public class ApplicationInsightsGeneratorTests
 
     private static (string FileName, SourceText SourceText) GetSourceFile(string content, string fileName)
     {
-        return (Path.Combine("Moq.AutoMocker.Generators", "Moq.AutoMocker.Generators.ApplicationInsightsExtensionSourceGenerator", fileName), SourceText.From(content, Encoding.UTF8));
+        return (Path.Combine("Moq.AutoMocker.Generators", "Moq.AutoMocker.Generators.ApplicationInsightsExtensionSourceGenerator", fileName), SourceText.From(content, Encoding.UTF8, SourceHashAlgorithm.Sha256));
     }
 
     public TestContext TestContext { get; set; }

--- a/Moq.AutoMocker.Generators.Tests/FakeLoggingGeneratorTests.cs
+++ b/Moq.AutoMocker.Generators.Tests/FakeLoggingGeneratorTests.cs
@@ -168,7 +168,7 @@ public class FakeLoggingGeneratorTests
 
     private static (string FileName, SourceText SourceText) GetSourceFile(string content, string fileName)
     {
-        return (Path.Combine("Moq.AutoMocker.Generators", "Moq.AutoMocker.Generators.FakeLoggingExtensionSourceGenerator", fileName), SourceText.From(content, Encoding.UTF8));
+        return (Path.Combine("Moq.AutoMocker.Generators", "Moq.AutoMocker.Generators.FakeLoggingExtensionSourceGenerator", fileName), SourceText.From(content, Encoding.UTF8, SourceHashAlgorithm.Sha256));
     }
 
     public TestContext TestContext { get; set; }

--- a/Moq.AutoMocker.Generators.Tests/GeneratorsTests.cs
+++ b/Moq.AutoMocker.Generators.Tests/GeneratorsTests.cs
@@ -202,7 +202,7 @@ public class GeneratorsTests
 
     private static (string FileName, SourceText SourceText) GetSourceFile(string content, string fileName)
     {
-        return (Path.Combine("Moq.AutoMocker.Generators", "Moq.AutoMocker.Generators.UnitTestSourceGenerator", fileName), SourceText.From(content, Encoding.UTF8));
+        return (Path.Combine("Moq.AutoMocker.Generators", "Moq.AutoMocker.Generators.UnitTestSourceGenerator", fileName), SourceText.From(content, Encoding.UTF8, SourceHashAlgorithm.Sha256));
     }
 
     public TestContext TestContext { get; set; }

--- a/Moq.AutoMocker.Generators.Tests/KeyedServicesGeneratorTests.cs
+++ b/Moq.AutoMocker.Generators.Tests/KeyedServicesGeneratorTests.cs
@@ -312,7 +312,7 @@ public class KeyedServicesGeneratorTests
 
     private static (string FileName, SourceText SourceText) GetSourceFile(string content, string fileName)
     {
-        return (Path.Combine("Moq.AutoMocker.Generators", "Moq.AutoMocker.Generators.KeyedServicesExtensionSourceGenerator", fileName), SourceText.From(content, Encoding.UTF8));
+        return (Path.Combine("Moq.AutoMocker.Generators", "Moq.AutoMocker.Generators.KeyedServicesExtensionSourceGenerator", fileName), SourceText.From(content, Encoding.UTF8, SourceHashAlgorithm.Sha256));
     }
 
     public TestContext TestContext { get; set; }

--- a/Moq.AutoMocker.Generators.Tests/MeterFactoryGeneratorTests.cs
+++ b/Moq.AutoMocker.Generators.Tests/MeterFactoryGeneratorTests.cs
@@ -143,7 +143,7 @@ public class MeterFactoryGeneratorTests
 
     private static (string FileName, SourceText SourceText) GetSourceFile(string content, string fileName)
     {
-        return (Path.Combine("Moq.AutoMocker.Generators", "Moq.AutoMocker.Generators.MeterFactoryExtensionSourceGenerator", fileName), SourceText.From(content, Encoding.UTF8));
+        return (Path.Combine("Moq.AutoMocker.Generators", "Moq.AutoMocker.Generators.MeterFactoryExtensionSourceGenerator", fileName), SourceText.From(content, Encoding.UTF8, SourceHashAlgorithm.Sha256));
     }
 
     public TestContext TestContext { get; set; }

--- a/Moq.AutoMocker.Generators.Tests/OptionsGeneratorTests.cs
+++ b/Moq.AutoMocker.Generators.Tests/OptionsGeneratorTests.cs
@@ -119,7 +119,7 @@ public class OptionsGeneratorTests
 
     private static (string FileName, SourceText SourceText) GetSourceFile(string content, string fileName)
     {
-        return (Path.Combine("Moq.AutoMocker.Generators", "Moq.AutoMocker.Generators.OptionsExtensionSourceGenerator", fileName), SourceText.From(content, Encoding.UTF8));
+        return (Path.Combine("Moq.AutoMocker.Generators", "Moq.AutoMocker.Generators.OptionsExtensionSourceGenerator", fileName), SourceText.From(content, Encoding.UTF8, SourceHashAlgorithm.Sha256));
     }
 
     public TestContext TestContext { get; set; }

--- a/Moq.AutoMocker.Generators.Tests/TestGeneratorTests.cs
+++ b/Moq.AutoMocker.Generators.Tests/TestGeneratorTests.cs
@@ -832,7 +832,7 @@ public class TestGeneratorTests
 
     private static (string FileName, SourceText SourceText) GetSourceFile(string content, string fileName)
     {
-        return (Path.Combine("Moq.AutoMocker.Generators", "Moq.AutoMocker.Generators.UnitTestSourceGenerator", fileName), SourceText.From(content, Encoding.UTF8));
+        return (Path.Combine("Moq.AutoMocker.Generators", "Moq.AutoMocker.Generators.UnitTestSourceGenerator", fileName), SourceText.From(content, Encoding.UTF8, SourceHashAlgorithm.Sha256));
     }
 
     public TestContext TestContext { get; set; }


### PR DESCRIPTION
Bumps versions for numerous packages in `Directory.Packages.props`, including `Microsoft.CodeAnalysis` and `Microsoft.Extensions.*` packages, to newer versions compatible with .NET 8.

Updates `SourceText.From` calls in test files to explicitly specify `SourceHashAlgorithm.Sha256`, as required by the updated `Microsoft.CodeAnalysis` APIs.
