### PR TITLE
Correct `AutoMocker.Use` instance check to use reference equality

### DIFF
--- a/Moq.AutoMock.Tests/DescribeUsingExplicitObjects.cs
+++ b/Moq.AutoMock.Tests/DescribeUsingExplicitObjects.cs
@@ -94,6 +94,46 @@ public class DescribeUsingExplicitObjects
     }
 
     [TestMethod]
+    public void It_does_not_throw_for_distinct_instances_that_are_value_equal()
+    {
+        // Reproduces https://github.com/moq/Moq.AutoMocker/issues/470
+        // Types like Uri override Equals to perform value equality, so two
+        // *different* instances that happen to represent the same value
+        // should not be treated as "the same instance already added".
+        AutoMocker mocker = new();
+        var uri1 = new Uri("relative", UriKind.Relative);
+        var uri2 = new Uri("relative", UriKind.Relative);
+        Assert.AreNotSame(uri1, uri2);
+        Assert.AreEqual(uri1, uri2);
+
+        mocker.Use(uri1);
+        mocker.Use(uri2);
+
+        Assert.AreSame(uri2, mocker.Get<Uri>());
+    }
+
+    [TestMethod]
+    public void It_does_not_throw_for_distinct_record_instances_that_are_value_equal()
+    {
+        // Reproduces https://github.com/moq/Moq.AutoMocker/issues/470
+        // Records generate value-based Equals overrides, so two distinct
+        // record instances with the same property values should not be
+        // treated as "the same instance already added".
+        AutoMocker mocker = new();
+        var record1 = new ExampleRecord("value");
+        var record2 = new ExampleRecord("value");
+        Assert.AreNotSame(record1, record2);
+        Assert.AreEqual(record1, record2);
+
+        mocker.Use(record1);
+        mocker.Use(record2);
+
+        Assert.AreSame(record2, mocker.Get<ExampleRecord>());
+    }
+
+    private record ExampleRecord(string Value);
+
+    [TestMethod]
     public void It_throws_if_the_service_was_created_by_mocker()
     {
         AutoMocker mocker = new();

--- a/Moq.AutoMock/AutoMocker.cs
+++ b/Moq.AutoMock/AutoMocker.cs
@@ -471,7 +471,7 @@ public partial class AutoMocker : IServiceProvider
         {
             if (typeMap.TryGetValue(type, out IInstance existingInstance) &&
                 existingInstance is RealInstance realInstance &&
-                Equals(realInstance.Value, service))
+                ReferenceEquals(realInstance.Value, service))
             {
                 throw new InvalidOperationException($"The service instance has already been added. You can safely remove this call to {nameof(AutoMocker)}.{nameof(Use)}");
             }
@@ -495,7 +495,7 @@ public partial class AutoMocker : IServiceProvider
             Type serviceType = typeof(TService);
             if (typeMap.TryGetValue(serviceType, out IInstance existingInstance) &&
                 existingInstance is MockInstance mockInstance &&
-                Equals(mockInstance.Mock.Object, mockedService.Object))
+                ReferenceEquals(mockInstance.Mock.Object, mockedService.Object))
             {
                 throw new InvalidOperationException("The service has already been added.");
             }


### PR DESCRIPTION
`AutoMocker.Use` previously used value equality (`Equals`) when checking if an object instance had already been registered. This led to an `InvalidOperationException` when distinct object instances that were value-equal (e.g., `Uri` objects or C# records with the same property values) were provided.

Fixes: #470

This change updates the check to use `ReferenceEquals`, ensuring that the exception is only thrown when the exact same object instance is added multiple times, not merely value-equal instances.

Fixes #470.
