### PR TITLE
Add release changelog configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,8 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - github-actions[bot]
+      - dependabot[bot]
+


### PR DESCRIPTION
Exclude bot authors and specific labels from the automatically generated release changelog. This helps keep release notes clean and focused on user-facing changes.
